### PR TITLE
fix: removed code that was throwing errors on extra arguments used by beam

### DIFF
--- a/pkg/cli/leech.go
+++ b/pkg/cli/leech.go
@@ -79,11 +79,6 @@ func (c *LeechCommand) RunUnstarted(ctx context.Context, args []string, storage 
 	if err := f.Parse(args); err != nil {
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
 	}
-	args = f.Args()
-	if len(args) > 0 {
-		return nil, fmt.Errorf("unexpected arguments: %q", args)
-	}
-
 	logger := logging.FromContext(ctx)
 	logger.Debugw("pipeline starting",
 		"name", version.Name,
@@ -97,6 +92,7 @@ func (c *LeechCommand) RunUnstarted(ctx context.Context, args []string, storage 
 
 	// initialize beam
 	beam.Init()
+
 	// setup the beam pipeline
 	p, s := beam.NewPipelineWithRoot()
 

--- a/pkg/cli/leech_test.go
+++ b/pkg/cli/leech_test.go
@@ -51,11 +51,6 @@ func TestLeechCommand(t *testing.T) {
 		expErr string
 	}{
 		{
-			name:   "too_many_args",
-			args:   []string{"foo"},
-			expErr: `unexpected arguments: ["foo"]`,
-		},
-		{
 			name: "happy_path",
 			env: map[string]string{
 				"BATCH_SIZE":         "100",


### PR DESCRIPTION
Apache Beam supplies a number of additional arguments when executed via the Dataflow runner. These were being flagged as invalid arguments which caused the pipeline to fail.