### PR TITLE
fix: pipeline deployment requires 'beta' gcloud installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
           service_account: '${{ vars.WIF_SERVICE_ACCOUNT }}'
       - name: 'Setup gcloud'
         uses: 'google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce' # ratchet:google-github-actions/setup-gcloud@v1
+        with:
+          install_components: 'beta'
       - name: 'Deploy dataflow pipeline'
         run: |-
           set +e +o pipefail


### PR DESCRIPTION
The `gcloud datapipelines pipeline` command is only in the beta version of `gcloud`. 

This PR enables installation of the beta components during gcloud setup.