### PR TITLE
Add views for Pull Request Review data

### DIFF
--- a/terraform/data/bq_views/events/pull_request_review_events.sql
+++ b/terraform/data/bq_views/events/pull_request_review_events.sql
@@ -1,0 +1,47 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Filters events to those just pertaining to pull request reviews.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  JSON_VALUE(payload, "$.organization.login") organization,
+  SAFE_CAST(JSON_QUERY(payload, "$.organization.id") AS INT64) organization_id,
+  JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
+  SAFE_CAST(JSON_QUERY(payload, "$.repository.id") AS INT64) repository_id,
+  JSON_VALUE(payload, "$.repository.name") repository,
+  JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
+  JSON_VALUE(payload, "$.sender.login") sender,
+  SAFE_CAST(JSON_QUERY(payload, "$.sender.id") AS INT64) sender_id,
+  SAFE_CAST(JSON_QUERY(payload, "$.pull_request.id") AS INT64) pull_request_id,
+  SAFE_CAST(JSON_QUERY(payload, "$.pull_request.number") AS INT64) pull_request_number,
+  JSON_VALUE(payload, "$.pull_request.state") pull_request_state,
+  JSON_VALUE(payload, "$.pull_request.url") pull_request_url,
+  SAFE_CAST(JSON_QUERY(payload, "$.pull_request.user.id") AS INT64) pull_request_author_id,
+  JSON_VALUE(payload, "$.pull_request.user.login") pull_request_author,
+  SAFE_CAST(JSON_QUERY(payload, "$.review.id") AS INT64) id,
+  JSON_VALUE(payload, "$.review.body") body,
+  JSON_VALUE(payload, "$.review.html_url") html_url,
+  JSON_VALUE(payload, "$.review.state") state,
+  TIMESTAMP(JSON_VALUE(payload, "$.review.submitted_at")) submitted_at,
+  JSON_VALUE(payload, "$.review.user.login") reviewer,
+  SAFE_CAST(JSON_QUERY(payload, "$.review.user.id") AS INT64) reviewer_id,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "pull_request_review";

--- a/terraform/data/bq_views/resources/pull_request_reviews.sql
+++ b/terraform/data/bq_views/resources/pull_request_reviews.sql
@@ -1,0 +1,50 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct pull_request_reviews from the pull_request_review_events view.
+-- The most recent event for each distinct review id is used to extract
+-- the review data. This ensures that the review data is up to date.
+
+SELECT
+  pull_request_review_events.body,
+  pull_request_review_events.html_url,
+  pull_request_review_events.id,
+  pull_request_review_events.organization,
+  pull_request_review_events.organization_id,
+  pull_request_review_events.pull_request_author,
+  pull_request_review_events.pull_request_author_id,
+  pull_request_review_events.pull_request_id,
+  pull_request_review_events.pull_request_number,
+  pull_request_review_events.pull_request_url,
+  pull_request_review_events.repository,
+  pull_request_review_events.repository_full_name,
+  pull_request_review_events.repository_id,
+  pull_request_review_events.repository_visibility,
+  pull_request_review_events.reviewer,
+  pull_request_review_events.reviewer_id,
+  pull_request_review_events.state,
+  pull_request_review_events.submitted_at,
+FROM
+  `${dataset_id}.${table_id}` pull_request_review_events
+INNER JOIN (
+  SELECT
+    id,
+    MAX(received) received
+  FROM
+    `${dataset_id}.${table_id}`
+  GROUP BY
+    id ) unique_pull_request_review_ids
+ON
+  pull_request_review_events.id = unique_pull_request_review_ids.id
+  AND pull_request_review_events.received = unique_pull_request_review_ids.received;


### PR DESCRIPTION
* Added `pull_request_review_events.sql` which creates a view that filters events to those only related to Pull Requests Reviews.
* Added `pull_request_reviews.sql` which provides a view of distinct pull requests reviews.