### PR TITLE
Add views for Workflow Run data

### DIFF
--- a/terraform/data/bq_views/events/workflow_run_events.sql
+++ b/terraform/data/bq_views/events/workflow_run_events.sql
@@ -1,0 +1,53 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Filters events to those just pertaining to workflow runs.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_run
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  JSON_VALUE(payload, "$.organization.login") organization,
+  SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
+  JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
+  SAFE_CAST(JSON_VALUE(payload, "$.repository.id") AS INT64) repository_id,
+  JSON_VALUE(payload, "$.repository.name") repository,
+  JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
+  JSON_VALUE(payload, "$.sender.login") sender,
+  SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
+  JSON_VALUE(payload, "$.workflow_run.actor.login") actor,
+  JSON_VALUE(payload, "$.workflow_run.conclusion") conclusion,
+  TIMESTAMP(JSON_VALUE(payload, "$.workflow_run.created_at")) created_at,
+  JSON_VALUE(payload, "$.workflow_run.display_title") display_title,
+  TIMESTAMP_DIFF(TIMESTAMP(JSON_VALUE(payload, "$.workflow_run.updated_at")), TIMESTAMP(JSON_VALUE(payload, "$.workflow_run.run_started_at")), SECOND) duration_seconds,
+  JSON_VALUE(payload, "$.workflow_run.event") workflow_event,
+  JSON_VALUE(payload, "$.workflow_run.head_branch") head_branch,
+  JSON_VALUE(payload, "$.workflow_run.head_sha") head_sha,
+  JSON_VALUE(payload, "$.workflow_run.html_url") html_url,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow_run.id") AS INT64) id,
+  JSON_VALUE(payload, "$.workflow_run.path") path,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow_run.run_attempt") AS INT64) run_attempt,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow_run.run_number") AS INT64) run_number,
+  TIMESTAMP(JSON_VALUE(payload, "$.workflow_run.run_started_at")) run_started_at,
+  JSON_VALUE(payload, "$.workflow_run.status") status,
+  TIMESTAMP(JSON_VALUE(payload, "$.workflow_run.updated_at")) updated_at,
+  JSON_VALUE(payload, "$.workflow_run.name") workflow_name,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow_run.workflow_id") AS INT64) workflow_id,
+  JSON_VALUE(payload, "$.workflow.html_url") workflow_html_url,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "workflow_run";

--- a/terraform/data/bq_views/resources/workflow_runs.sql
+++ b/terraform/data/bq_views/resources/workflow_runs.sql
@@ -1,0 +1,51 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct workflow_runs from the workflow_run_events view.
+-- The most recent event for each distinct workflow_run id is used to extract
+-- the workflow_run data. This ensures that the workflow_run data is up to date.
+
+SELECT
+  workflow_run_events.actor,
+  workflow_run_events.conclusion,
+  workflow_run_events.created_at,
+  workflow_run_events.display_title,
+  workflow_run_events.duration_seconds,
+  workflow_run_events.workflow_event,
+  workflow_run_events.head_branch,
+  workflow_run_events.head_sha,
+  workflow_run_events.html_url,
+  workflow_run_events.id,
+  workflow_run_events.path,
+  workflow_run_events.run_attempt,
+  workflow_run_events.run_number,
+  workflow_run_events.run_started_at,
+  workflow_run_events.status,
+  workflow_run_events.updated_at,
+  workflow_run_events.workflow_name,
+  workflow_run_events.workflow_id,
+  workflow_run_events.workflow_html_url,
+FROM
+  `${dataset_id}.${table_id}` workflow_run_events
+INNER JOIN (
+  SELECT
+    id,
+    MAX(received) received
+  FROM
+    `${dataset_id}.${table_id}`
+  GROUP BY
+    id ) unique_workflow_run_ids
+ON
+  workflow_run_events.id = unique_workflow_run_ids.id
+  AND workflow_run_events.received = unique_workflow_run_ids.received;


### PR DESCRIPTION
* Added `workflow_run_events.sql` which creates a view that filters events to those only related to Workflow Runs.
* Added `workflow_runs.sql` which provides a view of distinct workflow_runs.