### PR TITLE
Add views for Issue Comment data (#101)

### DIFF
--- a/terraform/data/bq_views/events/issue_comment_events.sql
+++ b/terraform/data/bq_views/events/issue_comment_events.sql
@@ -1,0 +1,44 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Filters events to those just pertaining to issue comments.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  JSON_VALUE(payload, "$.organization.login") organization,
+  SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
+  JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
+  SAFE_CAST(JSON_VALUE(payload, "$.repository.id") AS INT64) repository_id,
+  JSON_VALUE(payload, "$.repository.name") repository,
+  JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
+  JSON_VALUE(payload, "$.sender.login") sender,
+  SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
+  JSON_VALUE(payload, "$.comment.body") body,
+  SAFE_CAST(JSON_VALUE(payload, "$.comment.user.id") AS INT64) commenter_id,
+  JSON_VALUE(payload, "$.comment.user.login") commenter,
+  TIMESTAMP(JSON_VALUE(payload, "$.comment.created_at")) created_at,
+  JSON_VALUE(payload, "$.comment.html_url") html_url,
+  SAFE_CAST(JSON_VALUE(payload, "$.comment.id") AS INT64) id,
+  SAFE_CAST(JSON_VALUE(payload, "$.issue.id") AS INT64) issue_id,
+  SAFE_CAST(JSON_VALUE(payload, "$.comment.line") AS INT64) line,
+  JSON_VALUE(payload, "$.comment.path") path,
+  TIMESTAMP(JSON_VALUE(payload, "$.comment.updated_at")) updated_at,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "issue_comment";

--- a/terraform/data/bq_views/resources/issue_comment.sql
+++ b/terraform/data/bq_views/resources/issue_comment.sql
@@ -1,0 +1,42 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct pull_requests from the issue_comments.
+-- The most recent event for each distinct comment id is used to extract
+-- the comment data. This ensures that the comment data is up to date.
+
+SELECT
+  issue_comment_events.organization,
+  issue_comment_events.organization_id,
+  issue_comment_events.repository,
+  issue_comment_events.repository_id,
+  issue_comment_events.body,
+  issue_comment_events.commenter_id,
+  issue_comment_events.commenter,
+  issue_comment_events.created_at,
+  issue_comment_events.html_url,
+  issue_comment_events.id,
+  issue_comment_events.issue_id,
+  issue_comment_events.line,
+  issue_comment_events.path,
+  issue_comment_events.updated_at,
+FROM
+  `${dataset_id}.${table_id}` issue_comment_events
+JOIN (
+  SELECT id, max(received) received
+  FROM `${dataset_id}.${table_id}`
+  GROUP BY id
+) unique_issue_comment_ids
+ON issue_comment_events.id = unique_issue_comment_ids.id
+AND issue_comment_events.received = unique_issue_comment_ids.received;


### PR DESCRIPTION
* Added `issue_comment_events.sql` which creates a view that filters events to those only related to Issue Comments.
* Added `issue_comments.sql` which provides a view of distinct issue_comments.