### PR TITLE
Add views for Deployment data

### DIFF
--- a/terraform/data/bq_views/events/deployment_events.sql
+++ b/terraform/data/bq_views/events/deployment_events.sql
@@ -1,0 +1,48 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Filters events to those just pertaining to deployments.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#deployment
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  JSON_VALUE(payload, "$.organization.login") ORGANIZATION,
+  SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
+  JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
+  SAFE_CAST(JSON_VALUE(payload, "$.repository.id") AS INT64) repository_id,
+  JSON_VALUE(payload, "$.repository.name") repository,
+  JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
+  JSON_VALUE(payload, "$.sender.login") sender,
+  SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
+  TIMESTAMP(JSON_VALUE(payload, "$.deployment.created_at")) created_at,
+  JSON_QUERY(payload, "$.deployment.creator.login") creator,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment.creator.id") AS INT64) creator_id,
+  JSON_VALUE(payload, "$.deployment.description") description,
+  JSON_VALUE(payload, "$.deployment.environment") environment,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment.id") AS INT64) id,
+  JSON_VALUE(payload, "$.deployment.original_environment") original_environment,
+  JSON_VALUE(payload, "$.deployment.payload") deployment_payload,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment.production_environment") AS BOOL) production_environment,
+  JSON_VALUE(payload, "$.deployment.ref") ref,
+  JSON_VALUE(payload, "$.deployment.sha") sha,
+  JSON_VALUE(payload, "$.deployment.task") task,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment.transient_environment") AS BOOL) transient_environment,
+  TIMESTAMP(JSON_VALUE(payload, "$.deployment.updated_at")) updated_at,
+FROM 
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "deployment";

--- a/terraform/data/bq_views/resources/deployments.sql
+++ b/terraform/data/bq_views/resources/deployments.sql
@@ -1,0 +1,45 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct deployments from the deployment_events view.
+-- The most recent event for each distinct deployment id is used to extract
+-- the deployment data. This ensures that the deployment data is up to date.
+
+SELECT
+  deployment_events.organization,
+  deployment_events.organization_id,
+  deployment_events.repository_id,
+  deployment_events.repository,
+  deployment_events.created_at,
+  deployment_events.creator,
+  deployment_events.creator_id,
+  deployment_events.description,
+  deployment_events.environment,
+  deployment_events.id,
+  deployment_events.original_environment,
+  deployment_events.deployment_payload,
+  deployment_events.production_environment,
+  deployment_events.ref,
+  deployment_events.sha,
+  deployment_events.task,
+  deployment_events.transient_environment,
+  deployment_events.updated_at,
+FROM `${dataset_id}.${table_id}` deployment_events
+JOIN (
+  SELECT id, MAX(received) received
+  FROM `${dataset_id}.${table_id}`
+  GROUP BY id
+) unique_deployment_ids
+ON deployment_events.id = unique_deployment_ids.id
+AND deployment_events.received = unique_deployment_ids.received;


### PR DESCRIPTION
* Added `deployment_events.sql` which creates a view that filters events to those only related to Deployments.
* Added `deployments.sql` which provides a view of distinct deployments.