### PR TITLE
Add views for Deployment Status data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,9 @@ on:
   push:
     branches:
       - 'main'
-    paths-ignore:
-      - 'terraform/**'
   pull_request:
     branches:
       - 'main'
-    paths-ignore:
-      - 'terraform/**'
   workflow_dispatch:
 
 env:

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_status_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_status_events.sql
@@ -1,0 +1,47 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Filters events to those just pertaining to deployments.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#deployment_status
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  JSON_VALUE(payload, "$.organization.login") ORGANIZATION,
+  SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
+  JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
+  SAFE_CAST(JSON_VALUE(payload, "$.repository.id") AS INT64) repository_id,
+  JSON_VALUE(payload, "$.repository.name") repository,
+  JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
+  JSON_VALUE(payload, "$.sender.login") sender,
+  SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
+  SAFE_CAST(JSON_VALUE(payload, "$.check_run.id") AS INT64) check_run_id,
+  TIMESTAMP(JSON_VALUE(payload, "$.deployment_status.created_at")) created_at,
+  JSON_VALUE(payload, "$.deployment_status.creator.login") creator,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment_status.creator.id") AS INT64) creator_id,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment.id") AS INT64) deployment_id,
+  JSON_VALUE(payload, "$.deployment_status.description") description,
+  JSON_VALUE(payload, "$.deployment_status.environment") environment,
+  SAFE_CAST(JSON_VALUE(payload, "$.deployment_status.id") AS INT64) id,
+  JSON_VALUE(payload, "$.deployment_status.state") state,
+  JSON_VALUE(payload, "$.deployment_status.target_url") target_url,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow.id") AS INT64) workflow_id,
+  SAFE_CAST(JSON_VALUE(payload, "$.workflow_run.id") AS INT64) workflow_run_id,
+  TIMESTAMP(JSON_VALUE(payload, "$.deployment_status.updated_at")) updated_at,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "deployment_status";

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployment_statuses.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployment_statuses.sql
@@ -1,0 +1,49 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Extracts all distinct deployment_statuses from the deployment_status_events view.
+-- The most recent event for each distinct deployment_status id is used to extract
+-- the deployment_status data. This ensures that the deployment_status data is up to date.
+
+SELECT
+  deployment_status_events.organization,
+  deployment_status_events.organization_id,
+  deployment_status_events.repository_id,
+  deployment_status_events.repository,
+  deployment_status_events.check_run_id,
+  deployment_status_events.created_at,
+  deployment_status_events.creator,
+  deployment_status_events.creator_id,
+  deployment_status_events.deployment_id,
+  deployment_status_events.description,
+  deployment_status_events.environment,
+  deployment_status_events.id,
+  deployment_status_events.state,
+  deployment_status_events.target_url,
+  deployment_status_events.workflow_id,
+  deployment_status_events.workflow_run_id,
+  deployment_status_events.updated_at,
+FROM
+  `${dataset_id}.deployment_status_events` deployment_status_events
+JOIN (
+  SELECT
+    id,
+    MAX(received) received
+  FROM
+    `${dataset_id}.deployment_status_events`
+  GROUP BY
+    id ) unique_deployment_status_ids
+ON
+  deployment_status_events.id = unique_deployment_status_ids.id
+  AND deployment_status_events.received = unique_deployment_status_ids.received


### PR DESCRIPTION
* Added `deployment_status_events.sql` which creates a view that filters events to those only related to Deployment Statuses.
* Added `deployment_statuses.sql` which provides a view of distinct deployment statuses