### PR TITLE
Add views for Team data

### DIFF
--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/team_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/team_events.sql
@@ -1,0 +1,46 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Filters events to those just pertaining to teams.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#team
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  organization,
+  organization_id,
+  repository_full_name,
+  repository_id,
+  repository,
+  repository_visibility,
+  sender,
+  sender_id,
+  SAFE_CAST(JSON_VALUE(payload, "$.team.deleted") AS BOOL) deleted,
+  JSON_VALUE(payload, "$.team.description") description,
+  JSON_VALUE(payload, "$.team.html_url") html_url,
+  SAFE_CAST(JSON_VALUE(payload, "$.team.id") AS INT64) id,
+  JSON_VALUE(payload, "$.team.members_url") members_url,
+  JSON_VALUE(payload, "$.team.name") name,
+  SAFE_CAST(JSON_VALUE(payload, "$.team.parent.id") AS INT64) parent_id,
+  JSON_VALUE(payload, "$.team.parent.name") parent_name,
+  JSON_VALUE(payload, "$.team.permission") permission,
+  JSON_VALUE(payload, "$.team.privacy") privacy,
+  JSON_VALUE(payload, "$.team.notification_setting") notification_setting,
+  JSON_VALUE(payload, "$.team.slug") slug,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "team";

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/teams.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/teams.sql
@@ -1,0 +1,40 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct teams from the team_events view.
+-- The most recent event for each distinct team id is used to extract
+-- the team data. This ensures that the team data is up to date.
+
+SELECT
+  team_events.deleted,
+  team_events.description,
+  team_events.html_url,
+  team_events.id,
+  team_events.members_url,
+  team_events.name,
+  team_events.parent_id,
+  team_events.parent_name,
+  team_events.permission,
+  team_events.privacy,
+  team_events.notification_setting,
+  team_events.slug,
+FROM
+  `${dataset_id}.team_events` team_events
+JOIN(
+  SELECT id, MAX(received) received
+  FROM `${dataset_id}.team_events`
+  GROUP BY id
+) unique_team_ids
+ON team_events.id = unique_team_ids.id
+AND team_events.received = unique_team_ids.received;


### PR DESCRIPTION
* Added `team_events.sql` which creates a view that filters events to those only related to Teams.
* Added `teamss.sql` which provides a view of distinct teams.