### PR TITLE
fix: artifact pipeline ingestion not filtering correctly

### DIFF
--- a/pipeline/leech/main.go
+++ b/pipeline/leech/main.go
@@ -112,7 +112,7 @@ func realMain(ctx context.Context) error {
 	}
 
 	var event leech.EventRecord
-	query := fmt.Sprintf(leech.SourceQuery, eventsTableDotNotation, leechTableDotNotation, *batchSize, *batchSize)
+	query := fmt.Sprintf(leech.SourceQuery, eventsTableDotNotation, leechTableDotNotation, *batchSize)
 	// step 1: query BigQuery for unprocessed events
 	col := bigqueryio.Query(scope, *leechProjectID, query, reflect.TypeOf(event), bigqueryio.UseStandardSQL())
 	// step 2: process the events in parallel, ingesting logs

--- a/pkg/leech/ingest_logs.go
+++ b/pkg/leech/ingest_logs.go
@@ -79,8 +79,7 @@ AND JSON_VALUE(payload, "$.workflow_run.status") = "completed"
 AND delivery_id NOT IN (
 SELECT
   delivery_id
-FROM ` + "`%s`" + `
-LIMIT %d)
+FROM ` + "`%s`" + `)
 LIMIT %d
 `
 


### PR DESCRIPTION
The artifact pipeline is driven by a query against the events table that excludes rows that have already been processed.

The original version of the query had a limit clause in the nested `NOT IN` sub-select which was artificially excluding rows and causing events to be processed multiple times for some delivery ids.