### PR TITLE
Add views for Releases (#119)

### DIFF
--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/release_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/release_events.sql
@@ -1,0 +1,48 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Filters events to those just pertaining to releases.
+-- Relevant GitHub Docs:
+-- https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#release
+
+SELECT
+  received,
+  event,
+  JSON_VALUE(payload, "$.action") action,
+  organization,
+  organization_id,
+  repository_full_name,
+  repository_id,
+  repository,
+  repository_visibility,
+  sender,
+  sender_id,
+  JSON_VALUE(payload, "$.release.author.login") author,
+  SAFE_CAST(JSON_VALUE(payload, "$.release.author.id") AS INT64) author_id,
+  JSON_QUERY(payload, "$.release.body") body,
+  TIMESTAMP(JSON_VALUE(payload, "$.release.created_at")) created_at,
+  SAFE_CAST(JSON_VALUE(payload, "$.release.draft") AS BOOL) draft,
+  JSON_VALUE(payload, "$.release.html_url") html_url,
+  SAFE_CAST(JSON_VALUE(payload, "$.release.id") AS INT64) id,
+  JSON_VALUE(payload, "$.release.name") name,
+  SAFE_CAST(JSON_VALUE(payload, "$.release.prerelease") AS BOOL) prerelease,
+  JSON_VALUE(payload, "$.release.tag_name") tag_name,
+  JSON_VALUE(payload, "$.release.tarball_url") tarball_url,
+  JSON_VALUE(payload, "$.release.target_commitish") target_commitish,
+  JSON_VALUE(payload, "$.release.upload_url") upload_url,
+  JSON_VALUE(payload, "$.release.zipball_url") zipball_url,
+FROM
+  `${dataset_id}.${table_id}`
+WHERE
+  event = "release";

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/releases.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/releases.sql
@@ -1,0 +1,46 @@
+-- Copyright 2023 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Extracts all distinct releases from the release_events view.
+-- The most recent event for each distinct release id is used to extract
+-- the release data. This ensures that the release data is up to date.
+
+SELECT
+  releases_events.author,
+  releases_events.author_id,
+  releases_events.body,
+  releases_events.created_at,
+  releases_events.draft,
+  releases_events.html_url,
+  releases_events.id,
+  releases_events.name,
+  releases_events.prerelease,
+  releases_events.tag_name,
+  releases_events.tarball_url,
+  releases_events.target_commitish,
+  releases_events.upload_url,
+  releases_events.zipball_url,
+FROM
+  `${dataset_id}.releases_events` releases_events
+INNER JOIN (
+  SELECT
+    id,
+    MAX(received) received
+  FROM
+    `${dataset_id}.releases_events`
+  GROUP BY
+    id ) unique_release_ids
+ON
+  releases_events.id = unique_release_ids.id
+  AND releases_events.received = unique_release_ids.received;


### PR DESCRIPTION
* Added `release_events.sql` which creates a view that filters events to those only related to Releases.
* Added `releases.sql` which provides a view of distinct releases.