### PR TITLE
Pdewilde/fix query syntax

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -473,17 +473,17 @@ resource "google_bigquery_routine" "unique_events_by_date_type" {
     FROM
       `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.raw_events_table.table_id}`
     WHERE
-      received >= start
-      AND received <= end
+      received >= startDate
+      AND received <= endDate
       AND event = eventTypeFilter
     EOT
 
   arguments {
-    name      = "start"
+    name      = "startDate"
     data_type = jsonencode({ typeKind : "TIMESTAMP" })
   }
   arguments {
-    name      = "end"
+    name      = "endDate"
     data_type = jsonencode({ typeKind : "TIMESTAMP" })
   }
   arguments {

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -473,17 +473,17 @@ resource "google_bigquery_routine" "unique_events_by_date_type" {
     FROM
       `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.raw_events_table.table_id}`
     WHERE
-      received >= startDate
-      AND received <= endDate
+      received >= startTimestamp
+      AND received <= endTimestamp
       AND event = eventTypeFilter
     EOT
 
   arguments {
-    name      = "startDate"
+    name      = "startTimestamp"
     data_type = jsonencode({ typeKind : "TIMESTAMP" })
   }
   arguments {
-    name      = "endDate"
+    name      = "endTimestamp"
     data_type = jsonencode({ typeKind : "TIMESTAMP" })
   }
   arguments {

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -463,7 +463,7 @@ resource "google_bigquery_routine" "unique_events_by_date_type" {
       event,
       payload,
       LAX_STRING(payload.organization.login) organization,
-      SAFE.INT64(payload.organization.id)  organization_id,
+      SAFE.INT64(payload.organization.id) organization_id,
       LAX_STRING(payload.repository.full_name) repository_full_name,
       SAFE.INT64(payload.repository.id) repository_id,
       LAX_STRING(payload.repository.name) repository,

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -431,11 +431,11 @@ resource "google_bigquery_table" "unique_events_view" {
       JSON_VALUE(payload, "$.organization.login") organization,
       SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
       JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
-      SAFE_CAST(JSON_QUERY(payload, "$.repository.id") AS INT64) repository_id,
+      SAFE_CAST(JSON_VALUE(payload, "$.repository.id") AS INT64) repository_id,
       JSON_VALUE(payload, "$.repository.name") repository,
       JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
       JSON_VALUE(payload, "$.sender.login") sender,
-      SAFE_CAST(JSON_QUERY(payload, "$.sender.id") AS INT64) sender_id,
+      SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
     FROM
       `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.events_table.table_id}`
     EOT
@@ -462,14 +462,14 @@ resource "google_bigquery_routine" "unique_events_by_date_type" {
       received,
       event,
       payload,
-      JSON_VALUE(payload, "$.organization.login") organization,
-      SAFE_CAST(JSON_VALUE(payload, "$.organization.id") AS INT64) organization_id,
-      JSON_VALUE(payload, "$.repository.full_name") repository_full_name,
-      SAFE_CAST(JSON_QUERY(payload, "$.repository.id") AS INT64) repository_id,
-      JSON_VALUE(payload, "$.repository.name") repository,
-      JSON_VALUE(payload, "$.repository.visibility") repository_visibility,
-      JSON_VALUE(payload, "$.sender.login") sender,
-      SAFE_CAST(JSON_QUERY(payload, "$.sender.id") AS INT64) sender_id,
+      LAX_STRING(payload.organization.login) organization,
+      SAFE.INT64(payload.organization.id)  organization_id,
+      LAX_STRING(payload.repository.full_name) repository_full_name,
+      SAFE.INT64(payload.repository.id) repository_id,
+      LAX_STRING(payload.repository.name) repository,
+      LAX_STRING(payload.repository.visibility) repository_visibility,
+      LAX_STRING(payload.sender.login) sender,
+      SAFE.INT64(payload.sender.id) sender_id,
     FROM
       `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.raw_events_table.table_id}`
     WHERE


### PR DESCRIPTION
For the unique_events_view, JSON_VALUE is a more appropriate function as we would only ever cast a scalar value to an int anyways.

For the table function, payload is now a json type, so different syntax was more appropriate (also existing code was invalid due to differences in the return type of JSON_QUERY for a json string vs a json expression.