### PR TITLE
Table function requires project qualification

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -438,7 +438,7 @@ resource "google_bigquery_table" "unique_events_view" {
       SAFE_CAST(JSON_VALUE(payload, "$.sender.id") AS INT64) sender_id,
     FROM (
        SELECT ROW_NUMBER() OVER (PARTITION BY delivery_id ORDER BY received DESC) as row_id, *
-       FROM `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.events_table.table_id}`)
+       FROM `${google_bigquery_table.events_table.project}.${google_bigquery_table.events_table.dataset_id}.${google_bigquery_table.events_table.table_id}`)
     WHERE row_id = 1;
     EOT
     use_legacy_sql = false
@@ -474,7 +474,7 @@ resource "google_bigquery_routine" "unique_events_by_date_type" {
       SAFE.INT64(payload.sender.id) sender_id,
     FROM ( SELECT ROW_NUMBER() OVER (PARTITION BY delivery_id ORDER BY received DESC) as row_id, *
       FROM
-      `${google_bigquery_dataset.default.dataset_id}.${google_bigquery_table.raw_events_table.table_id}`
+      `${google_bigquery_table.raw_events_table.project}.${google_bigquery_table.raw_events_table.dataset_id}.${google_bigquery_table.raw_events_table.table_id}`
       WHERE
         received >= startTimestamp
         AND received <= endTimestamp


### PR DESCRIPTION
Though the error message suggests this should be fine since its in the same project.

```
  Error: Error creating Routine: googleapi: Error 400: Within a standard SQL table function, references to tables/views require explicit project IDs unless the entity is created in the same project that is issuing the query, but these references are not project-qualified: "github_metrics.raw_events", invalidQuery
  
    with module.github_metrics_aggregator.google_bigquery_routine.unique_events_by_date_type,
    on .terraform/modules/github_metrics_aggregator/terraform/bigquery.tf line 453, in resource "google_bigquery_routine" "unique_events_by_date_type":
   453: resource "google_bigquery_routine" "unique_events_by_date_type" {
```

Went ahead and fully qualified everything just to be safe.