### PR TITLE
Add delivery_id to views

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -38,10 +38,9 @@ import (
 
 const (
 	//nolint:gosec // This is a false positive for a variable name.
-	serverGitHubWebhookSecret = "test-github-webhook-secret"
-	serverProjectID           = "test-project-id"
-	serverEventsTopicID       = "test-events-topic-id"
-	//nolint:gosec // This is a false positive for a variable name.
+	serverGitHubWebhookSecret  = "test-github-webhook-secret"
+	serverProjectID            = "test-project-id"
+	serverEventsTopicID        = "test-events-topic-id"
 	serverDLQEventsTopicID     = "test-dlq-events-topic-id"
 	serverDatasetID            = "test-dataset-id"
 	serverEventsTableID        = "test-events-table-id"

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -700,7 +700,7 @@ resource "google_bigquery_table" "commit_review_status_table" {
       description : "The approval status of the commit in GitHub."
     },
     {
-      name : "break_glass_issue_url",
+      name : "break_glass_issue_urls",
       type : "STRING",
       mode : "REPEATED",
       description : "The URLs of the break glass issues that the author had open during the time the commit was made."

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/check_run_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/check_run_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_status_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/deployment_status_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/issue_comment_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/issue_comment_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/issue_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/issue_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_events.sql
@@ -15,6 +15,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_review_comment_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_review_comment_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_review_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/pull_request_review_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/push_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/push_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   organization,
   organization_id,
   repository_full_name,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/release_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/release_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/team_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/team_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/workflow_run_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/workflow_run_events.sql
@@ -19,6 +19,7 @@
 SELECT
   received,
   event,
+  delivery_id,
   JSON_VALUE(payload, "$.action") action,
   organization,
   organization_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/check_runs.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/check_runs.sql
@@ -26,6 +26,7 @@ SELECT
   check_run_events.check_suite_id,
   check_run_events.completed_at,
   check_run_events.conclusion,
+  check_run_events.delivery_id,
   check_run_events.deployment_id,
   check_run_events.details_url,
   check_run_events.external_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployment_statuses.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployment_statuses.sql
@@ -25,6 +25,7 @@ SELECT
   deployment_status_events.created_at,
   deployment_status_events.creator,
   deployment_status_events.creator_id,
+  deployment_status_events.delivery_id,
   deployment_status_events.deployment_id,
   deployment_status_events.description,
   deployment_status_events.environment,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployments.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/deployments.sql
@@ -24,6 +24,7 @@ SELECT
   deployment_events.created_at,
   deployment_events.creator,
   deployment_events.creator_id,
+  deployment_events.delivery_id,
   deployment_events.description,
   deployment_events.environment,
   deployment_events.id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/issue_comment.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/issue_comment.sql
@@ -25,6 +25,7 @@ SELECT
   issue_comment_events.commenter_id,
   issue_comment_events.commenter,
   issue_comment_events.created_at,
+  issue_comment_events.delivery_id,
   issue_comment_events.html_url,
   issue_comment_events.id,
   issue_comment_events.issue_id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/issues.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/issues.sql
@@ -25,6 +25,7 @@ SELECT
   issue_events.closed_at,
   issue_events.comments,
   issue_events.created_at,
+  issue_events.delivery_id,
   issue_events.draft,
   issue_events.html_url,
   issue_events.id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_request_review_comments.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_request_review_comments.sql
@@ -22,6 +22,7 @@ SELECT
   pull_request_review_comment_events.commenter_id,
   pull_request_review_comment_events.commit_sha,
   pull_request_review_comment_events.created_at,
+  pull_request_review_comment_events.delivery_id,
   pull_request_review_comment_events.diff_hunk,
   pull_request_review_comment_events.html_url,
   pull_request_review_comment_events.id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_request_reviews.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_request_reviews.sql
@@ -19,6 +19,7 @@
 SELECT
   pull_request_review_events.body,
   pull_request_review_events.commit_id,
+  pull_request_review_events.delivery_id,
   pull_request_review_events.html_url,
   pull_request_review_events.id,
   pull_request_review_events.organization,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_requests.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/pull_requests.sql
@@ -28,6 +28,7 @@ SELECT
   pull_request_events.commits,
   pull_request_events.created_at,
   pull_request_events.deletions,
+  pull_request_events.delivery_id,
   pull_request_events.draft,
   pull_request_events.head_ref,
   pull_request_events.html_url,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/releases.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/releases.sql
@@ -21,6 +21,7 @@ SELECT
   releases_events.author_id,
   releases_events.body,
   releases_events.created_at,
+  releases_events.delivery_id,
   releases_events.draft,
   releases_events.html_url,
   releases_events.id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/teams.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/teams.sql
@@ -18,6 +18,7 @@
 
 SELECT
   team_events.deleted,
+  team_events.delivery_id,
   team_events.description,
   team_events.html_url,
   team_events.id,

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/workflow_runs.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/workflow_runs.sql
@@ -20,6 +20,7 @@ SELECT
   workflow_run_events.actor,
   workflow_run_events.conclusion,
   workflow_run_events.created_at,
+  workflow_run_events.delivery_id,
   workflow_run_events.display_title,
   workflow_run_events.duration_seconds,
   workflow_run_events.workflow_event,


### PR DESCRIPTION
* Added `delivery_id` column to each view as it is the main mechanism we use to de-duplicate events. This makes it a useful field to have access to especially when conducting exploratory queries manually.
* Fixed typo in column name of the `commit_review_status_table`
* Also adjusted `pkg/webhook/webhook_test.go` because the linter is stupid and complaining about a file I didn't even touch.