### PR TITLE
Use GoogleSQL syntax for table name flags

### DIFF
--- a/pipeline/review/main.go
+++ b/pipeline/review/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/abcxyz/github-metrics-aggregator/pkg/review"
@@ -91,15 +92,15 @@ func getConfigFromFlags() (*review.CommitApprovalPipelineConfig, error) {
 	if githubToken == "" {
 		return nil, fmt.Errorf("a non-empty github-token must be provided")
 	}
-	qualifiedPushEventsTable, err := bigqueryio.NewQualifiedTableName(pushEventsTable)
+	qualifiedPushEventsTable, err := newQualifiedTableName(pushEventsTable)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse pushEventsTable: %w", err)
 	}
-	qualifiedCommitReviewStatusTable, err := bigqueryio.NewQualifiedTableName(commitReviewStatusTable)
+	qualifiedCommitReviewStatusTable, err := newQualifiedTableName(commitReviewStatusTable)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse commitReviewStatusTable: %w", err)
 	}
-	qualifiedIssuesTable, err := bigqueryio.NewQualifiedTableName(issuesTable)
+	qualifiedIssuesTable, err := newQualifiedTableName(issuesTable)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse issuesTable: %w", err)
 	}
@@ -109,4 +110,24 @@ func getConfigFromFlags() (*review.CommitApprovalPipelineConfig, error) {
 		CommitReviewStatusTable: qualifiedCommitReviewStatusTable,
 		IssuesTable:             qualifiedIssuesTable,
 	}, nil
+}
+
+// newQualifiedTableName parses a GoogleSQL table name, "<project>.<dataset>.<table>",
+// into a bigqueryio.QualifiedTableName. This is in contrast to
+// bigqueryio.NewQualifiedTableName, which parses a table name in BigQuery
+// Legacy SQL format.
+func newQualifiedTableName(s string) (bigqueryio.QualifiedTableName, error) {
+	c := strings.Index(s, ".")
+	d := strings.LastIndex(s, ".")
+	if c == -1 || d == -1 || d <= c {
+		return bigqueryio.QualifiedTableName{}, fmt.Errorf("table name missing components: %s", s)
+	}
+
+	project := s[:c]
+	dataset := s[c+1 : d]
+	table := s[d+1:]
+	if strings.TrimSpace(project) == "" || strings.TrimSpace(dataset) == "" || strings.TrimSpace(table) == "" {
+		return bigqueryio.QualifiedTableName{}, fmt.Errorf("table name has empty components: %s", s)
+	}
+	return bigqueryio.QualifiedTableName{Project: project, Dataset: dataset, Table: table}, nil
 }

--- a/pipeline/review/main.go
+++ b/pipeline/review/main.go
@@ -106,9 +106,9 @@ func getConfigFromFlags() (*review.CommitApprovalPipelineConfig, error) {
 	}
 	return &review.CommitApprovalPipelineConfig{
 		GitHubAccessToken:       githubToken,
-		PushEventsTable:         qualifiedPushEventsTable,
-		CommitReviewStatusTable: qualifiedCommitReviewStatusTable,
-		IssuesTable:             qualifiedIssuesTable,
+		PushEventsTable:         *qualifiedPushEventsTable,
+		CommitReviewStatusTable: *qualifiedCommitReviewStatusTable,
+		IssuesTable:             *qualifiedIssuesTable,
 	}, nil
 }
 
@@ -116,18 +116,18 @@ func getConfigFromFlags() (*review.CommitApprovalPipelineConfig, error) {
 // into a bigqueryio.QualifiedTableName. This is in contrast to
 // bigqueryio.NewQualifiedTableName, which parses a table name in BigQuery
 // Legacy SQL format.
-func newQualifiedTableName(s string) (bigqueryio.QualifiedTableName, error) {
+func newQualifiedTableName(s string) (*bigqueryio.QualifiedTableName, error) {
 	c := strings.Index(s, ".")
 	d := strings.LastIndex(s, ".")
 	if c == -1 || d == -1 || d <= c {
-		return bigqueryio.QualifiedTableName{}, fmt.Errorf("table name missing components: %s", s)
+		return nil, fmt.Errorf("table name missing components: %s", s)
 	}
 
 	project := s[:c]
 	dataset := s[c+1 : d]
 	table := s[d+1:]
 	if strings.TrimSpace(project) == "" || strings.TrimSpace(dataset) == "" || strings.TrimSpace(table) == "" {
-		return bigqueryio.QualifiedTableName{}, fmt.Errorf("table name has empty components: %s", s)
+		return nil, fmt.Errorf("table name has empty components: %s", s)
 	}
-	return bigqueryio.QualifiedTableName{Project: project, Dataset: dataset, Table: table}, nil
+	return &bigqueryio.QualifiedTableName{Project: project, Dataset: dataset, Table: table}, nil
 }

--- a/pipeline/review/main_test.go
+++ b/pipeline/review/main_test.go
@@ -27,13 +27,13 @@ func TestNewQualifiedTableName(t *testing.T) {
 	cases := []struct {
 		name      string
 		tableName string
-		want      bigqueryio.QualifiedTableName
+		want      *bigqueryio.QualifiedTableName
 		wantErr   string
 	}{
 		{
 			name:      "parses_google_sql_format",
 			tableName: "project.dataset.table",
-			want: bigqueryio.QualifiedTableName{
+			want: &bigqueryio.QualifiedTableName{
 				Project: "project",
 				Dataset: "dataset",
 				Table:   "table",

--- a/pipeline/review/main_test.go
+++ b/pipeline/review/main_test.go
@@ -1,0 +1,98 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/bigqueryio"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewQualifiedTableName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		tableName string
+		want      bigqueryio.QualifiedTableName
+		wantErr   string
+	}{
+		{
+			name:      "parses_google_sql_format",
+			tableName: "project.dataset.table",
+			want: bigqueryio.QualifiedTableName{
+				Project: "project",
+				Dataset: "dataset",
+				Table:   "table",
+			},
+		},
+		{
+			name:      "rejects_legacy_sql_format",
+			tableName: "project:dataset.table",
+			wantErr:   "table name missing components",
+		},
+		{
+			name:      "rejects_missing_first_period",
+			tableName: "projectdataset.table",
+			wantErr:   "table name missing components",
+		},
+		{
+			name:      "rejects_missing_second_period",
+			tableName: "project.datasettable",
+			wantErr:   "table name missing components",
+		},
+		{
+			name:      "rejects_missing_both_periods",
+			tableName: "projectdatasettable",
+			wantErr:   "table name missing components",
+		},
+		{
+			name:      "rejects_empty_string",
+			tableName: "",
+			wantErr:   "table name missing components",
+		},
+		{
+			name:      "rejects_missing_project",
+			tableName: ".dataset.table",
+			wantErr:   "table name has empty components",
+		},
+		{
+			name:      "rejects_missing_dataset",
+			tableName: "project..table",
+			wantErr:   "table name has empty components",
+		},
+		{
+			name:      "rejects_missing_table",
+			tableName: "project.dataset.",
+			wantErr:   "table name has empty components",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := newQualifiedTableName(tc.tableName)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("newQualifiedTableName got unexpected result (-got,+want):\n%s", diff)
+			}
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Errorf("newQualifiedTableName got unexpected error (-got,+want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/review/commit_review_status.go
+++ b/pkg/review/commit_review_status.go
@@ -391,18 +391,18 @@ func NewGitHubGraphQLClient(ctx context.Context, accessToken string) *githubv4.C
 // GetCommitQuery returns a BigQuery query that selects the commits that need
 // to be processed.
 func GetCommitQuery(pushEvents, commitReviewStatus bigqueryio.QualifiedTableName) string {
-	return fmt.Sprintf(commitQuery, sqlFormat(pushEvents), sqlFormat(commitReviewStatus))
+	return fmt.Sprintf(commitQuery, formatGoogleSQL(pushEvents), formatGoogleSQL(commitReviewStatus))
 }
 
 // GetBreakGlassIssueQuery returns a BigQuery query that searches for a
 // break glass issue created by given user and within a specified time frame.
 func GetBreakGlassIssueQuery(issues bigqueryio.QualifiedTableName, user, timestamp string) string {
-	return fmt.Sprintf(breakGlassIssueQuery, sqlFormat(issues), user, timestamp, timestamp)
+	return fmt.Sprintf(breakGlassIssueQuery, formatGoogleSQL(issues), user, timestamp, timestamp)
 }
 
-// sqlFormat formats the qualified name as "<project>.<dataset>.<table>"
-// so that it can be used in SQL queries.
-func sqlFormat(qualifiedTableName bigqueryio.QualifiedTableName) string {
+// formatGoogleSQL formats the qualified table name in GoogleSQL syntax.
+// i.e. "<project>.<dataset>.<table>".
+func formatGoogleSQL(qualifiedTableName bigqueryio.QualifiedTableName) string {
 	return fmt.Sprintf("%s.%s.%s", qualifiedTableName.Project, qualifiedTableName.Dataset, qualifiedTableName.Table)
 }
 


### PR DESCRIPTION
* Switched from using `bigqueryio.NewQualifiedTableName` to parse table names from flags to new custom function `newQualifiedTableName`. `bigqueryio.NewQualifiedTableName` required BigQuery Legacy SQL syntax, whereas `newQualifiedTableName` uses GoggleSQL syntax.
* renamed `review.sqlFormat` to `review.formatGoogleSQL` to better reflect that the purpose of this function was to format the table name in GooogleSQL syntax.