### PR TITLE
Add Note Column + Bugfixes

### DIFF
--- a/pkg/review/commit_review_status_test.go
+++ b/pkg/review/commit_review_status_test.go
@@ -669,7 +669,7 @@ func TestGetBreakGlassIssueQuery(t *testing.T) {
 			timestamp: "2023-08-15T23:21:34Z",
 			want: `
 SELECT
-  issues.html_url
+  issues.html_url html_url
 FROM
   ` + "`my_project.my_dataset.issues`" + ` issues
 WHERE
@@ -873,6 +873,7 @@ func TestCommitApprovalDoFn_ProcessElement(t *testing.T) {
 				PullRequestNumber:  48,
 				PullRequestHTMLURL: "https://github.com/my-org/my-repo/pull/48",
 				ApprovalStatus:     GithubPRApproved,
+				BreakGlassURLs:     []string{},
 			},
 		},
 		{
@@ -948,6 +949,7 @@ func TestCommitApprovalDoFn_ProcessElement(t *testing.T) {
 				PullRequestNumber:  52,
 				PullRequestHTMLURL: "https://github.com/my-org/my-repo/pull/52",
 				ApprovalStatus:     GithubPRApproved,
+				BreakGlassURLs:     []string{},
 			},
 		},
 		{
@@ -1023,6 +1025,7 @@ func TestCommitApprovalDoFn_ProcessElement(t *testing.T) {
 				PullRequestNumber:  48,
 				PullRequestHTMLURL: "https://github.com/my-org/my-repo/pull/48",
 				ApprovalStatus:     "REVIEW_REQUIRED",
+				BreakGlassURLs:     []string{},
 			},
 		},
 		{
@@ -1082,6 +1085,7 @@ func TestCommitApprovalDoFn_ProcessElement(t *testing.T) {
 				},
 				HTMLURL:        "https://github.com/test-org/test-repository/commit/12345678",
 				ApprovalStatus: DefaultApprovalStatus,
+				BreakGlassURLs: []string{},
 			},
 		},
 		{

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -705,6 +705,12 @@ resource "google_bigquery_table" "commit_review_status_table" {
       mode : "REPEATED",
       description : "The URLs of the break glass issues that the author had open during the time the commit was made."
     },
+    {
+      name : "note",
+      type : "STRING",
+      mode : "NULLABLE",
+      description : "Optional context on the about the commit (e.g. a processing error message)"
+    },
   ])
 }
 


### PR DESCRIPTION
* Add a note column to supply optional additional context on why the approval status for a commit was not able to be obtained
* Add special case handling for the error where a commit's repository has been deleted from GitHub
* Made it so that `CommitReviewStatus.BreakGlassURLs` is initalized to an empty slice rather than `nil`
* Fixed typo in bigquery tag for the `breakGlassIssue.HTMLURL` field