### PR TITLE
refactor: move webhook and retry service account impersonation to terraform module

### DIFF
--- a/terraform/service_retry.tf
+++ b/terraform/service_retry.tf
@@ -140,7 +140,7 @@ module "retry_cloud_run" {
 
 # allow the ci service account to act as the retry cloud run service account
 # this allows the ci service account to deploy new revisions for the cloud run
-# sevice
+# service
 resource "google_service_account_iam_member" "retry_run_sa_user" {
   service_account_id = google_service_account.retry_run_service_account.name
   role               = "roles/iam.serviceAccountUser"

--- a/terraform/service_retry.tf
+++ b/terraform/service_retry.tf
@@ -85,7 +85,7 @@ resource "google_cloud_scheduler_job" "retry_scheduler" {
   ]
 }
 
-# Cloud Run 
+# Cloud Run
 
 resource "google_service_account" "retry_run_service_account" {
   project = data.google_project.default.project_id
@@ -136,4 +136,13 @@ module "retry_cloud_run" {
     google_storage_bucket.retry_lock,
     google_service_account.retry_invoker,
   ]
+}
+
+# allow the ci service account to act as the retry cloud run service account
+# this allows the ci service account to deploy new revisions for the cloud run
+# sevice
+resource "google_service_account_iam_member" "retry_run_sa_user" {
+  service_account_id = google_service_account.retry_run_service_account.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.automation_service_account_member
 }

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -64,7 +64,7 @@ module "webhook_cloud_run" {
 
 # allow the ci service account to act as the webhook cloud run service account
 # this allows the ci service account to deploy new revisions for the cloud run
-# sevice
+# service
 resource "google_service_account_iam_member" "webhook_run_sa_user" {
   service_account_id = google_service_account.webhook_run_service_account.name
   role               = "roles/iam.serviceAccountUser"

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -68,5 +68,5 @@ module "webhook_cloud_run" {
 resource "google_service_account_iam_member" "webhook_run_sa_user" {
   service_account_id = google_service_account.webhook_run_service_account.name
   role               = "roles/iam.serviceAccountUser"
-  member             = local.automation_service_account_member
+  member             = var.automation_service_account_member
 }

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -61,3 +61,12 @@ module "webhook_cloud_run" {
     }
   }
 }
+
+# allow the ci service account to act as the webhook cloud run service account
+# this allows the ci service account to deploy new revisions for the cloud run
+# sevice
+resource "google_service_account_iam_member" "webhook_run_sa_user" {
+  service_account_id = google_service_account.webhook_run_service_account.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = local.automation_service_account_member
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,7 +29,7 @@ variable "prefix_name" {
 
 variable "automation_service_account_member" {
   description = "The service account member used for deploying new revisions"
-  type = "string"
+  type        = string
 }
 
 # This current approach allows the end-user to disable the GCLB in favor of calling the Cloud Run service directly.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,8 +27,13 @@ variable "prefix_name" {
   }
 }
 
+variable "automation_service_account_member" {
+  description = "The service account member used for deploying new revisions"
+  type = "string"
+}
+
 # This current approach allows the end-user to disable the GCLB in favor of calling the Cloud Run service directly.
-# This was done to use tagged revision URLs for integration testing on multiple pull requests. 
+# This was done to use tagged revision URLs for integration testing on multiple pull requests.
 # TODO(https://github.com/abcxyz/github-metrics-aggregator/issues/45)
 variable "enable_webhook_gclb" {
   description = "Enable the use of a Google Cloud load balancer for the webhook Cloud Run service. By default this is true, this should only be used for integration environments where services will use tagged revision URLs for testing."


### PR DESCRIPTION
The [webhook](https://github.com/abcxyz/infra-gcp/blob/main/terraform/deployment-resources/github-metrics-aggregator/production/main.tf#L63) and [retry](https://github.com/abcxyz/infra-gcp/blob/main/terraform/deployment-resources/github-metrics-aggregator/production/main.tf#L72) service accounts are impersonated by the automation service account for deploying new revisions to Cloud Run. These should be moved to within the GMA terraform module as a core requirement.