### PR TITLE
fix: remove quotes when setting pipeline params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
           pipeline_type: 'BATCH'
           pipeline_schedule: '*/15 * * * *'
           pipeline_experiments: 'use_prime'
-          pipeline_parameters: 'batch-size=100,events-project-id="${{ env.AUTOPUSH_PROJECT_ID }}",events-table="github_metrics.events",leech-project-id="${{ env.AUTOPUSH_PROJECT_ID }}",leech-table="github_metrics.leech_status",logs-bucket-name="github-metrics-aggreg-a-997e5e-df-store/artifacts",github-app-id="${{ secrets.GH_APP_ID }}",github-install-id="${{ secrets.GH_INSTALL_ID }}",github-private-key-secret="${{ secrets.GH_PRIVATE_KEY_SECRET }}'
+          pipeline_parameters: 'batch-size=100,events-project-id=${{ env.AUTOPUSH_PROJECT_ID }},events-table=github_metrics.events,leech-project-id=${{ env.AUTOPUSH_PROJECT_ID }},leech-table=github_metrics.leech_status,logs-bucket-name=github-metrics-aggreg-a-997e5e-df-store/artifacts,github-app-id=${{ secrets.GH_APP_ID }},github-install-id=${{ secrets.GH_INSTALL_ID }},github-private-key-secret=${{ secrets.GH_PRIVATE_KEY_SECRET }}'
 
   deployment_commit_review_status_pipeline_autopush:
     if: ${{ github.event_name == 'push' }}
@@ -336,4 +336,4 @@ jobs:
           pipeline_type: 'BATCH'
           pipeline_schedule: '0 */4 * * *'
           pipeline_experiments: 'use_prime'
-          pipeline_parameters: 'github-app-id="${{ secrets.GH_APP_ID }}",github-app-installation-id="${{ secrets.GH_INSTALL_ID }}",github-app-private-key-resource-name="${{ secrets.GH_PRIVATE_KEY_SECRET }}",push-events-table="${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.push_events",commit-review-status-table="${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.commit_review_status",issues-table="${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.issues'
+          pipeline_parameters: 'github-app-id=${{ secrets.GH_APP_ID }},github-app-installation-id=${{ secrets.GH_INSTALL_ID }},github-app-private-key-resource-name=${{ secrets.GH_PRIVATE_KEY_SECRET }},push-events-table=${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.push_events,commit-review-status-table=${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.commit_review_status,issues-table=${{ env.AUTOPUSH_PROJECT_ID }}.github_metrics.issues'


### PR DESCRIPTION
* Removed quotes from pipeline params as the params are not evaluated in shell like context resulting in the quotes being escaped and passed along as part of the parameter value.