### PR TITLE
chore: update Cloud Run module and Google provider version

### DIFF
--- a/abc.templates/infra/contents/terraform.tf
+++ b/abc.templates/infra/contents/terraform.tf
@@ -22,7 +22,7 @@ terraform {
 
   required_providers {
     google = {
-      version = ">= 4.45"
+      version = ">= 4.83"
     }
     github = {
       source  = "integrations/github"

--- a/terraform/service_retry.tf
+++ b/terraform/service_retry.tf
@@ -96,7 +96,7 @@ resource "google_service_account" "retry_run_service_account" {
 
 # This service is internal facing, and will only be invoked by the scheduler
 module "retry_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=129d7928a4ed16d7b51ea5aca9df77018d8e7632"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=e7f268b6a29e130eb81e2b7250f6b67a9ae03bd3"
 
   project_id = data.google_project.default.project_id
 

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -15,7 +15,7 @@
 module "gclb" {
   count = var.enable_webhook_gclb ? 1 : 0
 
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/gclb_cloud_run_backend?ref=129d7928a4ed16d7b51ea5aca9df77018d8e7632"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/gclb_cloud_run_backend?ref=e7f268b6a29e130eb81e2b7250f6b67a9ae03bd3"
 
   project_id = data.google_project.default.project_id
 
@@ -32,7 +32,7 @@ resource "google_service_account" "webhook_run_service_account" {
 }
 
 module "webhook_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=129d7928a4ed16d7b51ea5aca9df77018d8e7632"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=e7f268b6a29e130eb81e2b7250f6b67a9ae03bd3"
 
   project_id = data.google_project.default.project_id
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -16,7 +16,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     google = {
-      version = ">= 4.45"
+      version = ">= 4.83"
     }
   }
 }


### PR DESCRIPTION
This change fixes the error thrown when using legacy `automatic = true` instead of new `auto {}` block inside of `google_secret_manager_secret` `replication` block, introduced since Google Provider `>= 4.83.0`.

```
Error: Unsupported argument
248:     automatic = true

An argument named "automatic" is not expected here.
```