### PR TITLE
fix: handle null reviewDecision

### DIFF
--- a/pkg/review/commit_review_status.go
+++ b/pkg/review/commit_review_status.go
@@ -488,10 +488,12 @@ func GetPullRequestsTargetingDefaultBranch(ctx context.Context, client *githubv4
 		// Only select pull requests made against the default branch.
 		for _, pr := range query.Repository.Object.Commit.AssociatedPullRequest.Nodes {
 			if pr.BaseRefName == query.Repository.DefaultBranchRef.Name {
+				if pr.ReviewDecision == "" {
+					pr.ReviewDecision = DefaultApprovalStatus
+				}
 				pullRequests = append(pullRequests, pr)
 			}
 		}
-
 		if !query.Repository.Object.Commit.AssociatedPullRequest.PageInfo.HasNextPage {
 			break
 		}

--- a/pkg/review/commit_review_status_test.go
+++ b/pkg/review/commit_review_status_test.go
@@ -554,6 +554,178 @@ func TestGetPullRequests(t *testing.T) {
          }`,
 			},
 		},
+		{
+			name:       "null_review_decision_mapped_to_default_status",
+			token:      "fake_token",
+			githubOrg:  "test-org",
+			repository: "test-repo",
+			commitSha:  "kof6p96lr6qvdu81qw49fhmoxrod9qmc2qak51nh",
+			wantRequestBodies: []string{
+				`{
+           "query": "
+             query($commitSha:GitObjectID! $githubOrg:String! $pageCursor:String! $repository:String!) {
+               repository(owner: $githubOrg, name: $repository) {
+                 defaultBranchRef {
+                   name
+                 },
+                 object(oid: $commitSha) {
+                   ... on Commit{
+                     associatedPullRequests(first: 100, after: $pageCursor) {
+                       nodes{
+                         baseRefName,
+                         databaseId,
+                         number,
+                         reviewDecision,
+                         url
+                       },
+                       pageInfo{
+                         endCursor,
+                         hasNextPage,
+                         hasPreviousPage,
+                         startCursor
+                       },
+                       totalCount
+                     }
+                   }
+                 }
+               }
+             }
+           ",
+           "variables": {
+             "commitSha": "kof6p96lr6qvdu81qw49fhmoxrod9qmc2qak51nh",
+             "githubOrg": "test-org",
+             "pageCursor": "",
+             "repository":"test-repo"
+           }
+         }`,
+			},
+			want: []*PullRequest{
+				{
+					BaseRefName:    "main",
+					DatabaseID:     1,
+					Number:         23,
+					ReviewDecision: "UNKNOWN",
+					URL:            "https://github.com/my-org/my-repo/pull/23",
+				},
+			},
+			responseBodies: []string{
+				`{
+           "data": {
+             "repository": {
+               "defaultBranchRef": {
+                 "name": "main"
+               },
+               "object": {
+                 "associatedPullRequests": {
+                   "nodes": [
+                     {
+                       "baseRefName": "main",
+                       "databaseId": 1,
+                       "number": 23,
+                       "reviewDecision": null,
+                       "url": "https://github.com/my-org/my-repo/pull/23"
+                     }
+                   ],
+                   "pageInfo": {
+                     "endCursor": "XQ",
+                     "hasNextPage": false,
+                     "hasPreviousPage": false,
+                     "startCursor": ""
+                   },
+                   "totalCount": 1
+                 }
+               }
+             }
+           }
+         }`,
+			},
+		},
+		{
+			name:       "empty_review_decision_mapped_to_default_status",
+			token:      "fake_token",
+			githubOrg:  "test-org",
+			repository: "test-repo",
+			commitSha:  "kof6p96lr6qvdu81qw49fhmoxrod9qmc2qak51nh",
+			wantRequestBodies: []string{
+				`{
+           "query": "
+             query($commitSha:GitObjectID! $githubOrg:String! $pageCursor:String! $repository:String!) {
+               repository(owner: $githubOrg, name: $repository) {
+                 defaultBranchRef {
+                   name
+                 },
+                 object(oid: $commitSha) {
+                   ... on Commit{
+                     associatedPullRequests(first: 100, after: $pageCursor) {
+                       nodes{
+                         baseRefName,
+                         databaseId,
+                         number,
+                         reviewDecision,
+                         url
+                       },
+                       pageInfo{
+                         endCursor,
+                         hasNextPage,
+                         hasPreviousPage,
+                         startCursor
+                       },
+                       totalCount
+                     }
+                   }
+                 }
+               }
+             }
+           ",
+           "variables": {
+             "commitSha": "kof6p96lr6qvdu81qw49fhmoxrod9qmc2qak51nh",
+             "githubOrg": "test-org",
+             "pageCursor": "",
+             "repository":"test-repo"
+           }
+         }`,
+			},
+			want: []*PullRequest{
+				{
+					BaseRefName:    "main",
+					DatabaseID:     1,
+					Number:         23,
+					ReviewDecision: "UNKNOWN",
+					URL:            "https://github.com/my-org/my-repo/pull/23",
+				},
+			},
+			responseBodies: []string{
+				`{
+           "data": {
+             "repository": {
+               "defaultBranchRef": {
+                 "name": "main"
+               },
+               "object": {
+                 "associatedPullRequests": {
+                   "nodes": [
+                     {
+                       "baseRefName": "main",
+                       "databaseId": 1,
+                       "number": 23,
+                       "reviewDecision": "",
+                       "url": "https://github.com/my-org/my-repo/pull/23"
+                     }
+                   ],
+                   "pageInfo": {
+                     "endCursor": "XQ",
+                     "hasNextPage": false,
+                     "hasPreviousPage": false,
+                     "startCursor": ""
+                   },
+                   "totalCount": 1
+                 }
+               }
+             }
+           }
+         }`,
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc


### PR DESCRIPTION
Github may return a null value for the `reviewDecision` of a PR. In these cases we should map the review status to the default value `UNKOWN`