### PR TITLE
Refactor how Token permissions are requested

### DIFF
--- a/pipeline/review/main.go
+++ b/pipeline/review/main.go
@@ -118,7 +118,17 @@ func realMain(ctx context.Context) error {
 			return merr
 		}
 
-		githubTokenSource, err = githubauth.NewAppTokenSource(*flagGitHubAppID, *flagGitHubAppInstallationID, privateKeyPEM, githubauth.ForAllRepos())
+		githubTokenSource, err = githubauth.NewAppTokenSource(
+			*flagGitHubAppID,
+			*flagGitHubAppInstallationID,
+			privateKeyPEM,
+			githubauth.ForAllRepos(),
+			map[string]string{
+				"actions":       "read",
+				"contents":      "read",
+				"pull_requests": "read",
+			},
+		)
 		if err != nil {
 			merr = errors.Join(merr, fmt.Errorf("failed to create github app token source: %w", err))
 			return merr

--- a/pkg/leech/ingest_logs.go
+++ b/pkg/leech/ingest_logs.go
@@ -117,7 +117,17 @@ func (f *IngestLogsFn) StartBundle(ctx context.Context) error {
 	f.storage = store
 
 	// Create the GitHub App.
-	githubTokenSource, err := githubauth.NewAppTokenSource(f.GitHubAppID, f.GitHubInstallID, f.GitHubPrivateKey, githubauth.ForAllRepos())
+	githubTokenSource, err := githubauth.NewAppTokenSource(
+		f.GitHubAppID,
+		f.GitHubInstallID,
+		f.GitHubPrivateKey,
+		githubauth.ForAllRepos(),
+		map[string]string{
+			"actions":       "read",
+			"contents":      "read",
+			"pull_requests": "read",
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create github auth: %w", err)
 	}


### PR DESCRIPTION
* Changed token permissions that are to be used when requesting a token to be supplied by the caller when creating the GitHubApp. This is because the set of permissions needed varies based on the use case for the token.