### PR TITLE
fix: grant the automation service accounts developer permissions

### DIFF
--- a/abc.templates/infra/contents/main.tf
+++ b/abc.templates/infra/contents/main.tf
@@ -15,17 +15,13 @@ module "REPLACE_MODULE_NAME" {
   github_app_id                     = "REPLACE_GITHUB_APP_ID"
   log_level                         = "info"
   retry_service_iam = {
-    admins = []
-    developers = [
-      local.automation_service_account_member, # permissions to deploy revisions
-    ]
-    invokers = []
+    admins     = []
+    developers = []
+    invokers   = []
   }
   webhook_service_iam = {
-    admins = []
-    developers = [
-      local.automation_service_account_member, # permissions to deploy revisions
-    ]
+    admins     = []
+    developers = []
     invokers = [
       "allUsers", # public access, called by github webhook
     ]

--- a/abc.templates/infra/contents/main.tf
+++ b/abc.templates/infra/contents/main.tf
@@ -15,14 +15,20 @@ module "REPLACE_MODULE_NAME" {
   github_app_id                     = "REPLACE_GITHUB_APP_ID"
   log_level                         = "info"
   retry_service_iam = {
-    admins     = []
-    developers = []
-    invokers   = []
+    admins = []
+    developers = [
+      local.automation_service_account_member, # permissions to deploy revisions
+    ]
+    invokers = []
   }
   webhook_service_iam = {
-    admins     = []
-    developers = []
-    invokers   = ["allUsers"] # public access, called by github webhook
+    admins = []
+    developers = [
+      local.automation_service_account_member, # permissions to deploy revisions
+    ]
+    invokers = [
+      "allUsers", # public access, called by github webhook
+    ]
   }
   dataset_iam = {
     owners  = []

--- a/terraform/service_retry.tf
+++ b/terraform/service_retry.tf
@@ -108,9 +108,9 @@ module "retry_cloud_run" {
   secrets               = ["github-private-key"]
   service_account_email = google_service_account.retry_run_service_account.email
   service_iam = {
-    admins     = var.retry_service_iam.admins
-    developers = var.retry_service_iam.developers
-    invokers   = concat([google_service_account.retry_invoker.member], var.retry_service_iam.invokers)
+    admins     = toset(var.retry_service_iam.admins)
+    developers = toset(var.retry_service_iam.developers)
+    invokers   = toset(concat([google_service_account.retry_invoker.member], var.retry_service_iam.invokers))
   }
   envvars = {
     "BIG_QUERY_PROJECT_ID" : var.bigquery_project_id,

--- a/terraform/service_retry.tf
+++ b/terraform/service_retry.tf
@@ -109,7 +109,7 @@ module "retry_cloud_run" {
   service_account_email = google_service_account.retry_run_service_account.email
   service_iam = {
     admins     = toset(var.retry_service_iam.admins)
-    developers = toset(var.retry_service_iam.developers)
+    developers = toset(concat(var.retry_service_iam.developers, [var.automation_service_account_member]))
     invokers   = toset(concat([google_service_account.retry_invoker.member], var.retry_service_iam.invokers))
   }
   envvars = {

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -43,7 +43,11 @@ module "webhook_cloud_run" {
   ingress               = var.enable_webhook_gclb ? "internal-and-cloud-load-balancing" : "all"
   secrets               = ["github-webhook-secret"]
   service_account_email = google_service_account.webhook_run_service_account.email
-  service_iam           = var.webhook_service_iam
+  service_iam = {
+    admins     = toset(var.webhook_service_iam.admins)
+    developers = toset(var.webhook_service_iam.developers)
+    invokers   = toset(var.webhook_service_iam.invokers)
+  }
   envvars = {
     "BIG_QUERY_PROJECT_ID" : var.bigquery_project_id,
     "DATASET_ID" : google_bigquery_dataset.default.dataset_id,

--- a/terraform/service_webhook.tf
+++ b/terraform/service_webhook.tf
@@ -45,7 +45,7 @@ module "webhook_cloud_run" {
   service_account_email = google_service_account.webhook_run_service_account.email
   service_iam = {
     admins     = toset(var.webhook_service_iam.admins)
-    developers = toset(var.webhook_service_iam.developers)
+    developers = toset(concat(var.webhook_service_iam.developers, [var.automation_service_account_member]))
     invokers   = toset(var.webhook_service_iam.invokers)
   }
   envvars = {


### PR DESCRIPTION
This change grants the automation service account permissions to make revisions to the cloud run services and also `toset`'s on each of the service IAM configurations to avoid duplicate assignments.

I considered granting the developer role on the service account when rendering the template (see commit [042503b](https://github.com/abcxyz/github-metrics-aggregator/pull/236/commits/042503bced88472b5f6fa63b455c674b3a6fe336)), because this would make it more explicit which IAM roles are assigned. But I decided against that idea, because the terraform module should provide everything that is required to run the service, even if that means the role assignment is hidden in the module itself.