### PR TITLE
Output commit review status table id

### DIFF
--- a/terraform/modules/commit_review_status/outputs.tf
+++ b/terraform/modules/commit_review_status/outputs.tf
@@ -1,0 +1,4 @@
+
+output "commit_review_status_table_id" {
+  value = var.commit_review_status_table_id
+}

--- a/terraform/modules/commit_review_status/outputs.tf
+++ b/terraform/modules/commit_review_status/outputs.tf
@@ -1,4 +1,4 @@
 
 output "commit_review_status_table_id" {
-  value = var.commit_review_status_table_id
+  value = google_bigquery_table.commit_review_status_table.table_id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -73,7 +73,7 @@ output "bigquery_unique_events_view_id" {
 
 output "bigquery_commit_review_status_table_id" {
   description = "BigQuery commit_review_status table resource."
-  value       = var.commit_review_status.enabled ? module.commit_review_status[0].commit_review_status_table_id : null
+  value       = try(module.commit_review_status[0].commit_review_status_table_id, null)
 }
 
 output "bigquery_event_views" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -71,6 +71,11 @@ output "bigquery_unique_events_view_id" {
   value       = google_bigquery_table.unique_events_view.table_id
 }
 
+output "bigquery_commit_review_status_table_id" {
+  description = "BigQuery commit_review_status table resource."
+  value       = var.commit_review_status.enabled ? module.commit_review_status.commit_review_status_table_id : null
+}
+
 output "bigquery_event_views" {
   description = "BigQuery event view resources."
   value       = module.metrics_views.bigquery_event_views

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -73,7 +73,7 @@ output "bigquery_unique_events_view_id" {
 
 output "bigquery_commit_review_status_table_id" {
   description = "BigQuery commit_review_status table resource."
-  value       = var.commit_review_status.enabled ? module.commit_review_status.commit_review_status_table_id : null
+  value       = var.commit_review_status.enabled ? module.commit_review_status[0].commit_review_status_table_id : null
 }
 
 output "bigquery_event_views" {


### PR DESCRIPTION
Output the commit review status table id so that we can refer to it in the infra-gcp terraform