### PR TITLE
rename pr_stats_dashboard input to github_metrics_dashboard

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -547,8 +547,8 @@ module "invocation_comment" {
 }
 
 # add all groups who need to view through lookerstudio to jobUser role
-resource "google_project_iam_member" "pr_stats_dashboard_job_users" {
-  for_each = var.pr_stats_dashboard.enabled ? toset(var.pr_stats_dashboard.viewers) : []
+resource "google_project_iam_member" "github_metrics_dashboard_job_users" {
+  for_each = var.github_metrics_dashboard.enabled ? toset(var.github_metrics_dashboard.viewers) : []
 
   project = var.project_id
 
@@ -557,8 +557,8 @@ resource "google_project_iam_member" "pr_stats_dashboard_job_users" {
 }
 
 # grant users access to the dataset used for displaying PR stats
-resource "google_bigquery_dataset_iam_member" "pr_stats_dashboard_data_viewers" {
-  for_each = var.pr_stats_dashboard.enabled ? toset(var.pr_stats_dashboard.viewers) : []
+resource "google_bigquery_dataset_iam_member" "github_metrics_dashboard_data_viewers" {
+  for_each = var.github_metrics_dashboard.enabled ? toset(var.github_metrics_dashboard.viewers) : []
 
   project = var.project_id
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -91,12 +91,12 @@ output "bigquery_pubsub_destination" {
   value       = format("${google_bigquery_table.events_table.project}:${google_bigquery_table.events_table.dataset_id}.${google_bigquery_table.events_table.table_id}")
 }
 
-output "pr_stats_looker_studio_report_link" {
-  description = "The Looker Studio Linking API link for connecting the data sources for the PR Stats dashboard."
-  value = var.pr_stats_dashboard.enabled ? join("",
+output "github_metrics_looker_studio_report_link" {
+  description = "The Looker Studio Linking API link for connecting the data sources for the GitHub Metrics dashboard."
+  value = var.github_metrics_dashboard.enabled ? join("",
     [
       "https://lookerstudio.google.com/reporting/create",
-      "?c.reportId=${var.pr_stats_dashboard.looker_report_id}",
+      "?c.reportId=${var.github_metrics_dashboard.looker_report_id}",
       "&r.reportName=GitHub%20Metrics",
       "&ds.ds0.keepDatasourceName",
       "&ds.ds0.connector=bigQuery",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -354,11 +354,11 @@ variable "invocation_comment" {
   }
 }
 
-variable "pr_stats_dashboard" {
-  description = "The configuration for the PR Stats dashboard"
+variable "github_metrics_dashboard" {
+  description = "The configuration for the GitHub Metrics dashboard"
   type = object({
     enabled          = bool
-    looker_report_id = optional(string, "de3a9011-f38b-4d9a-a48e-23fe58186589") # abcxyz-provided PR stats report template
+    looker_report_id = optional(string, "de3a9011-f38b-4d9a-a48e-23fe58186589") # abcxyz-provided GitHub Metrics report template
     viewers          = optional(list(string), [])
   })
   default = {


### PR DESCRIPTION
This change generalizes the dashboard name in case the base dashboard includes more than PR stats.