### PR TITLE
Add code audit dashboard terraform

### DIFF
--- a/abc.templates/infra/contents/main.tf
+++ b/abc.templates/infra/contents/main.tf
@@ -31,6 +31,12 @@ module "REPLACE_MODULE_NAME" {
     editors = []
     viewers = []
   }
+  code_audit_dashboard = {
+    enabled = false
+    table_iam = {
+      viewers = []
+    }
+  }
   github_metrics_dashboard = {
     enabled = false
     viewers = []

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -523,15 +523,15 @@ module "leech" {
 }
 
 module "commit_review_status" {
-  count = var.commit_review_status.enabled ? 1 : 0
+  count = var.code_audit_dashboard.enabled ? 1 : 0
 
   source = "./modules/commit_review_status"
 
   project_id = var.project_id
 
   dataset_id                     = google_bigquery_dataset.default.dataset_id
-  commit_review_status_table_id  = var.commit_review_status.table_id
-  commit_review_status_table_iam = var.commit_review_status.table_iam
+  commit_review_status_table_id  = var.code_audit_dashboard.table_id
+  commit_review_status_table_iam = var.code_audit_dashboard.table_iam
 }
 
 module "invocation_comment" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,3 +32,12 @@ resource "google_project_service" "default" {
   service            = each.value
   disable_on_destroy = false
 }
+
+module "dataflow_vpc" {
+  # This may be shared across multiple features and not exclusive to code audit.
+  # If another feature takes a dependency on dataflow, then it should be added
+  # to the conditional below.
+  count = var.code_audit_dashboard.enabled ? 1 : 0
+
+  project_id = var.project_id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,5 +39,7 @@ module "dataflow_vpc" {
   # to the conditional below.
   count = var.code_audit_dashboard.enabled ? 1 : 0
 
+  source = "./modules/dataflow_vpc"
+
   project_id = var.project_id
 }

--- a/terraform/modules/commit_review_status/main.tf
+++ b/terraform/modules/commit_review_status/main.tf
@@ -138,3 +138,13 @@ resource "google_bigquery_table_iam_member" "commit_review_status_viewers" {
   role       = "roles/bigquery.dataViewer"
   member     = each.value
 }
+
+# add all groups who need to view through lookerstudio to jobUser role
+resource "google_project_iam_member" "code_audit_dashboard_job_users" {
+  for_each = var.pr_stats_dashboard.enabled ? toset(var.commit_review_status_table_iam.viewers) : []
+
+  project = var.project_id
+
+  role   = "roles/bigquery.jobUser"
+  member = each.value
+}

--- a/terraform/modules/commit_review_status/main.tf
+++ b/terraform/modules/commit_review_status/main.tf
@@ -141,7 +141,11 @@ resource "google_bigquery_table_iam_member" "commit_review_status_viewers" {
 
 # add all groups who need to view through lookerstudio to jobUser role
 resource "google_project_iam_member" "code_audit_dashboard_job_users" {
-  for_each = var.pr_stats_dashboard.enabled ? toset(var.commit_review_status_table_iam.viewers) : []
+  for_each = toset(concat(
+    var.commit_review_status_table_iam.viewers,
+    var.commit_review_status_table_iam.editors,
+    var.commit_review_status_table_iam.owners
+  ))
 
   project = var.project_id
 

--- a/terraform/modules/commit_review_status/main.tf
+++ b/terraform/modules/commit_review_status/main.tf
@@ -141,11 +141,7 @@ resource "google_bigquery_table_iam_member" "commit_review_status_viewers" {
 
 # add all groups who need to view through lookerstudio to jobUser role
 resource "google_project_iam_member" "code_audit_dashboard_job_users" {
-  for_each = toset(concat(
-    var.commit_review_status_table_iam.viewers,
-    var.commit_review_status_table_iam.editors,
-    var.commit_review_status_table_iam.owners
-  ))
+  for_each = toset(concat(var.commit_review_status_table_iam.viewers, var.commit_review_status_table_iam.editors, var.commit_review_status_table_iam.owners))
 
   project = var.project_id
 

--- a/terraform/modules/dataflow_vpc/main.tf
+++ b/terraform/modules/dataflow_vpc/main.tf
@@ -1,0 +1,92 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "github_ip_ranges" "gh_ranges" {}
+
+# add a vpc for dataflow to use
+resource "google_compute_network" "dataflow_vpc" {
+  project = var.project_id
+
+  name                    = "gma-df-vpc"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "dataflow_vpc_sub" {
+  project = var.project_id
+
+  name = "gma-df-us-central1"
+
+  ip_cidr_range = "10.1.0.0/26"
+  region        = "us-central1"
+  network       = google_compute_network.dataflow_vpc.id
+}
+
+resource "google_compute_firewall" "dataflow_vpc_rule_node" {
+  project = var.project_id
+
+  name        = "gma-df-fw-rule-node"
+  network     = google_compute_network.dataflow_vpc.name
+  description = "Allow traffic between 'dataflow' nodes"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["12345-12346"]
+  }
+
+  source_tags = ["dataflow"]
+  target_tags = ["dataflow"]
+}
+
+resource "google_compute_firewall" "dataflow_vpc_outbound" {
+  project = var.project_id
+
+  name        = "gma-df-fw-rule-outbound"
+  network     = google_compute_network.dataflow_vpc.name
+  description = "Allow 'dataflow' outbound traffic for GitHub access"
+
+  direction          = "EGRESS"
+  destination_ranges = data.github_ip_ranges.gh_ranges.api_ipv4
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+}
+
+resource "google_compute_router" "dataflow_router" {
+  project = var.project_id
+
+  name    = "gma-df-router"
+  network = google_compute_network.dataflow_vpc.name
+  region  = "us-central1"
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "dataflow_nat" {
+  project = var.project_id
+
+  name                               = "gma-df-router-nat"
+  router                             = google_compute_router.dataflow_router.name
+  region                             = google_compute_router.dataflow_router.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/terraform/modules/dataflow_vpc/main.tf
+++ b/terraform/modules/dataflow_vpc/main.tf
@@ -25,10 +25,10 @@ resource "google_compute_network" "dataflow_vpc" {
 resource "google_compute_subnetwork" "dataflow_vpc_sub" {
   project = var.project_id
 
-  name = "gma-df-us-central1"
+  name = "gma-df-${var.region}"
 
   ip_cidr_range = "10.1.0.0/26"
-  region        = "us-central1"
+  region        = var.region
   network       = google_compute_network.dataflow_vpc.id
 }
 
@@ -69,7 +69,7 @@ resource "google_compute_router" "dataflow_router" {
 
   name    = "gma-df-router"
   network = google_compute_network.dataflow_vpc.name
-  region  = "us-central1"
+  region  = var.region
 
   bgp {
     asn = 64514

--- a/terraform/modules/dataflow_vpc/terraform.tf
+++ b/terraform/modules/dataflow_vpc/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 The Authors (see AUTHORS file)
+# Copyright 2024 The Authors (see AUTHORS file)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@ terraform {
   required_providers {
     google = {
       version = ">= 4.83"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform/modules/dataflow_vpc/terraform.tf
+++ b/terraform/modules/dataflow_vpc/terraform.tf
@@ -1,0 +1,22 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      version = ">= 4.83"
+    }
+  }
+}

--- a/terraform/modules/dataflow_vpc/variables.tf
+++ b/terraform/modules/dataflow_vpc/variables.tf
@@ -16,3 +16,9 @@ variable "project_id" {
   description = "The GCP project ID."
   type        = string
 }
+
+variable "region" {
+  description = "The Google Cloud region to deploy the subnet in (defaults to 'us-central1')."
+  type        = string
+  default     = "us-central1"
+}

--- a/terraform/modules/dataflow_vpc/variables.tf
+++ b/terraform/modules/dataflow_vpc/variables.tf
@@ -1,0 +1,18 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project ID."
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -322,11 +322,12 @@ variable "leech" {
   }
 }
 
-variable "commit_review_status" {
+variable "code_audit_dashboard" {
   description = "The configuration block for commit review status"
   type = object({
-    enabled  = bool
-    table_id = optional(string, null)
+    enabled          = bool
+    looker_report_id = optional(string, "2f73dfbc-2c11-47cc-a914-116a5b60f485") # abcxyz-provided PR stats report template
+    table_id         = optional(string, null)
     table_iam = optional(object({
       owners  = optional(list(string), [])
       editors = optional(list(string), [])

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -323,7 +323,7 @@ variable "leech" {
 }
 
 variable "code_audit_dashboard" {
-  description = "The configuration block for commit review status"
+  description = "The configuration block for code audit table and dashboard"
   type = object({
     enabled          = bool
     looker_report_id = optional(string, "2f73dfbc-2c11-47cc-a914-116a5b60f485") # abcxyz-provided PR stats report template


### PR DESCRIPTION
- Renames input var from `commit_review_stats` to `code_audit_dashboard`.
- Adds VPC terraform module (for dataflow dependency)
- Adds IAM for viewing through Looker Studio dashboard