### PR TITLE
Fix HTTP Method

### DIFF
--- a/terraform/modules/artifacts/cloud_run_job.tf
+++ b/terraform/modules/artifacts/cloud_run_job.tf
@@ -99,7 +99,7 @@ resource "google_cloud_scheduler_job" "scheduler" {
   }
 
   http_target {
-    http_method = "GET"
+    http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.default.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.default.name}:run"
     oidc_token {
       service_account_email = google_service_account.default.email

--- a/terraform/modules/commit_review_status/cloud_run_job.tf
+++ b/terraform/modules/commit_review_status/cloud_run_job.tf
@@ -99,7 +99,7 @@ resource "google_cloud_scheduler_job" "scheduler" {
   }
 
   http_target {
-    http_method = "GET"
+    http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.default.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.default.name}:run"
     oidc_token {
       service_account_email = google_service_account.default.email


### PR DESCRIPTION
Invoking a cloud run job via a HTTP request needs to use `POST` instead of `GET` Documentation: https://cloud.google.com/run/docs/execute/jobs#execute_jobs