### PR TITLE
Fix scheduler authentication

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,7 +51,7 @@ module "leech" {
   github_private_key_secret_id      = var.github_private_key_secret_id
   github_private_key_secret_version = var.github_private_key_secret_version
   job_name                          = var.artifacts_job_name
-  scheduler_cron                    = "*/15 * * * *"
+  scheduler_cron                    = var.artifacts_scheduler_cron
 }
 
 module "commit_review_status" {
@@ -71,5 +71,5 @@ module "commit_review_status" {
   issues_table_id                   = module.metrics_views.bigquery_resource_views["issues.sql"]
   commit_review_status_table_id     = var.commit_review_status.table_id
   commit_review_status_table_iam    = var.commit_review_status.table_iam
-  scheduler_cron                    = "0 */4 * * *"
+  scheduler_cron                    = var.commit_review_status_scheduler_cron
 }

--- a/terraform/modules/artifacts/cloud_run_job.tf
+++ b/terraform/modules/artifacts/cloud_run_job.tf
@@ -101,7 +101,7 @@ resource "google_cloud_scheduler_job" "scheduler" {
   http_target {
     http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.default.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.default.name}:run"
-    oidc_token {
+    oauth_token {
       service_account_email = google_service_account.default.email
     }
   }

--- a/terraform/modules/commit_review_status/cloud_run_job.tf
+++ b/terraform/modules/commit_review_status/cloud_run_job.tf
@@ -101,7 +101,7 @@ resource "google_cloud_scheduler_job" "scheduler" {
   http_target {
     http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.default.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.default.name}:run"
-    oidc_token {
+    oauth_token {
       service_account_email = google_service_account.default.email
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -378,10 +378,22 @@ variable "artifacts_job_name" {
   default     = "artifacts-job"
 }
 
+variable "artifacts_scheduler_cron" {
+  description = "The cron schedule to run the artifacts Cloud Run job"
+  type        = string
+  default     = "*/15 * * * *"
+}
+
 variable "commit_review_status_job_name" {
   description = "The name to give the artifacts Cloud Run job"
   type        = string
   default     = "commit-review-status-job"
+}
+
+variable "commit_review_status_scheduler_cron" {
+  description = "The cron schedule to run the commit review status Cloud Run job"
+  type        = string
+  default     = "0 */4 * * *"
 }
 
 variable "github_private_key_secret_id" {


### PR DESCRIPTION
* Use OAUTH token instead of OICD token
* Make cron schedule for each job configurable via a terraform variable