### PR TITLE
fix: Fix timestamp type and add storage role

### DIFF
--- a/pkg/review/commit_query.go
+++ b/pkg/review/commit_query.go
@@ -34,7 +34,7 @@ WITH
     push_events.repository_default_branch branch,
     push_events.repository_visibility visibility,
     JSON_VALUE(commit_json, '$.id') commit_sha,
-    JSON_VALUE(commit_json, '$.timestamp') commit_timestamp,
+    TIMESTAMP(JSON_VALUE(commit_json, '$.timestamp')) commit_timestamp,
   FROM
     {{.BT}}{{.ProjectID}}.{{.DatasetID}}.{{.PushEventsTableID}}{{.BT}} push_events,
     UNNEST(push_events.commits) commit_json

--- a/pkg/review/commit_query_test.go
+++ b/pkg/review/commit_query_test.go
@@ -40,7 +40,7 @@ WITH
     push_events.repository_default_branch branch,
     push_events.repository_visibility visibility,
     JSON_VALUE(commit_json, '$.id') commit_sha,
-    JSON_VALUE(commit_json, '$.timestamp') commit_timestamp,
+    TIMESTAMP(JSON_VALUE(commit_json, '$.timestamp')) commit_timestamp,
   FROM
     ` + "`my_project.my_dataset.push_events`" + ` push_events,
     UNNEST(push_events.commits) commit_json

--- a/terraform/modules/artifacts/cloud_run_job.tf
+++ b/terraform/modules/artifacts/cloud_run_job.tf
@@ -115,6 +115,14 @@ resource "google_bigquery_table_iam_member" "artifacts_table_editor_role" {
   member     = google_service_account.default.member
 }
 
+// give the service account permission to write storage objects
+resource "google_project_iam_member" "storage_object_user_role" {
+  project = var.project_id
+
+  member = google_service_account.default.member
+  role   = "roles/storage.objectUser"
+}
+
 resource "google_cloud_scheduler_job" "scheduler" {
   project = var.project_id
 


### PR DESCRIPTION
* Add missing storage creation role to artifact job sevice account.
* Need to parse timestamp as TIMESTAMP type due to changes made in #285