### PR TITLE
Fix bug with release condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,18 @@ concurrency:
 jobs:
   log-trigger-condition-if-skipped:
     if: |-
-      ${{ ! (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.head_commit.message, 'Release: v')) }}
+      ${{ ! (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_commit.message, 'Release: v')) }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Log create release trigger vars'
         run: |-
           echo "github.event.workflow_run.conclusion: ${{ github.event.workflow_run.conclusion }}"
-          echo "github.event.head_commit.message: ${{ github.event.head_commit.message }}"
+          echo "github.event.workflow_run.head_commit.message: ${{ github.event.workflow_run.head_commit.message }}"
 
   create-release:
     # trigger only when ci workflow completes successfully and the head commit message starts with 'Release: v'
     if: |-
-      ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.head_commit.message, 'Release: v') }}
+      ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_commit.message, 'Release: v') }}
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'


### PR DESCRIPTION
`head_commit` must be read from the `workflow_run` event object