### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/pkg/artifact/ingest_logs_test.go
+++ b/pkg/artifact/ingest_logs_test.go
@@ -124,8 +124,6 @@ func TestPipeline_handleMessage(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -316,8 +314,6 @@ func TestPipeline_commentArtifactOnPRs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/bq/bigquery_test.go
+++ b/pkg/bq/bigquery_test.go
@@ -116,7 +116,6 @@ func TestRowsToSlice(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, _ := rowsToSlice[TestStruct](tc.rows, tc.totalRows)

--- a/pkg/cli/retry_test.go
+++ b/pkg/cli/retry_test.go
@@ -124,8 +124,6 @@ func TestRetryServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/webhook_test.go
+++ b/pkg/cli/webhook_test.go
@@ -145,8 +145,6 @@ func TestWebhookServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/retry/config_test.go
+++ b/pkg/retry/config_test.go
@@ -146,8 +146,6 @@ func TestConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -246,8 +246,6 @@ func TestHandleRetry(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/review/breakglass_query_test.go
+++ b/pkg/review/breakglass_query_test.go
@@ -49,8 +49,6 @@ WHERE
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/review/commit_query_test.go
+++ b/pkg/review/commit_query_test.go
@@ -66,8 +66,6 @@ WHERE
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/review/commit_review_status_test.go
+++ b/pkg/review/commit_review_status_test.go
@@ -964,8 +964,6 @@ func TestGetPullRequests(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -981,7 +979,7 @@ func TestGetPullRequests(t *testing.T) {
 				bytes, _ := io.ReadAll(r.Body)
 				requestBody := string(bytes)
 				gotRequestBodies = append(gotRequestBodies, requestBody)
-				fmt.Fprintf(w, tc.responseBodies[requestNumber])
+				fmt.Fprint(w, tc.responseBodies[requestNumber])
 				requestNumber++
 			}))
 			src := oauth2.StaticTokenSource(
@@ -1111,8 +1109,6 @@ func TestGetPullRequest(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := getApprovingPullRequest(tc.pullRequests)
@@ -1141,8 +1137,6 @@ func TestGetCommitHtmlUrl(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := getCommitHTMLURL(tc.commit)
@@ -1504,8 +1498,6 @@ func TestProcessCommit(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			fakeGitHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1516,7 +1508,7 @@ func TestProcessCommit(t *testing.T) {
 					return
 				}
 				w.WriteHeader(tc.graphQlResponseCode)
-				fmt.Fprintf(w, tc.graphQLResponse)
+				fmt.Fprint(w, tc.graphQLResponse)
 			}))
 			src := oauth2.StaticTokenSource(
 				&oauth2.Token{AccessToken: tc.token},
@@ -1655,7 +1647,6 @@ func TestProcessReviewStatus(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/pkg/webhook/config_test.go
+++ b/pkg/webhook/config_test.go
@@ -157,8 +157,6 @@ func TestConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -221,8 +221,6 @@ func TestHandleWebhook(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer required as of Go 1.22+