### PR TITLE
Disable work-in-progress monitoring dashboard

### DIFF
--- a/terraform/dashboard.tf
+++ b/terraform/dashboard.tf
@@ -1,4 +1,6 @@
 resource "google_monitoring_dashboard" "default" {
+  count = var.enable_monitoring_dashboard ? 1 : 0
+
   project = var.project_id
 
   dashboard_json = file("${path.module}/dashboards/default.json")

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -542,3 +542,9 @@ variable "alert_notification_channel_non_paging" {
     }
   }
 }
+
+variable "enable_monitoring_dashboard" {
+  description = "Enable the Google monitoring dashboard (WIP). Defaults to false."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Unrelated Guardian plans are attempting to create this, temporarily disable this in the meantime.