### PR TITLE
Add enterprise view

### DIFF
--- a/terraform/modules/bigquery_metrics_views/data/bq_views/events/enterprise_events.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/events/enterprise_events.sql
@@ -1,0 +1,25 @@
+
+-- Copyright 2025 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Extracts all events containing enterprise information from the raw_events table.
+-- This view serves as the base for the final `enterprises` resource view.
+
+SELECT
+  SAFE.INT64(payload.enterprise.id) AS id
+FROM
+  `${raw_events_table_id}` -- Note: This variable must be passed to the template
+WHERE
+  -- Filter for events that contain enterprise information
+  payload.enterprise.id IS NOT NULL;

--- a/terraform/modules/bigquery_metrics_views/data/bq_views/resources/enterprises.sql
+++ b/terraform/modules/bigquery_metrics_views/data/bq_views/resources/enterprises.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 The Authors (see AUTHORS file)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Extracts a distinct list of all enterprise IDs from the enterprise_events view.
+
+SELECT DISTINCT
+  id AS enterprise_id
+FROM
+  `${dataset_id}.enterprise_events`;


### PR DESCRIPTION
Adds a enterprises view with a unique list of enterprise IDs, sourced from the raw_events table.

This uses the existing module automation by adding:
- enterprise_events.sql
- enterprises.sql