### PR TITLE
Enable github_metrics_dashboard

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -425,8 +425,8 @@ variable "github_metrics_dashboard" {
     viewers          = optional(list(string), [])
   })
   default = {
-    enabled = false
-    viewers = []
+    enabled = true
+    viewers = [user:ruizhg@gmail.com]
   }
 }
 


### PR DESCRIPTION
To view the Looker Studio dashboard, enable it and add the viewers.

I have two questions:
1. I was exploring how to set the "github_metrics_dashboard" variable, but I haven't found a good way to do so. 
2. For viewers, I simply used my own email for testing.