### PR TITLE
fix: ensure BQ project id is used where appropriate

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,7 +74,7 @@ module "bigquery_infra" {
   count  = var.bigquery_infra_deploy ? 1 : 0
   source = "./modules/bigquery_infra"
 
-  project_id = var.project_id
+  project_id = var.bigquery_project_id
 
   dataset_id                            = var.dataset_id
   dataset_location                      = var.dataset_location
@@ -100,6 +100,7 @@ module "leech" {
 
   project_id = var.project_id
 
+  bigquery_project_id                  = var.bigquery_project_id
   image                                = var.image
   dataset_id                           = var.dataset_id
   leech_bucket_name                    = var.leech.bucket_name
@@ -137,6 +138,7 @@ module "commit_review_status" {
 
   project_id = var.project_id
 
+  bigquery_project_id                  = var.bigquery_project_id
   image                                = var.image
   dataset_id                           = var.dataset_id
   github_app_id                        = var.github_app_id

--- a/terraform/modules/artifacts/main.tf
+++ b/terraform/modules/artifacts/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "google_bigquery_table" "leech_table" {
-  project = var.project_id
+  project = var.bigquery_project_id
 
   deletion_protection = false
   table_id            = var.leech_table_id
@@ -85,7 +85,7 @@ resource "google_bigquery_table" "leech_table" {
 resource "google_bigquery_table_iam_member" "leech_owners" {
   for_each = toset(var.leech_table_iam.owners)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.leech_table.id
@@ -96,7 +96,7 @@ resource "google_bigquery_table_iam_member" "leech_owners" {
 resource "google_bigquery_table_iam_member" "leech_editors" {
   for_each = toset(var.leech_table_iam.editors)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.leech_table.id
@@ -107,7 +107,7 @@ resource "google_bigquery_table_iam_member" "leech_editors" {
 resource "google_bigquery_table_iam_member" "leech_viewers" {
   for_each = toset(var.leech_table_iam.viewers)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.leech_table.id

--- a/terraform/modules/artifacts/variables.tf
+++ b/terraform/modules/artifacts/variables.tf
@@ -22,6 +22,11 @@ variable "dataset_id" {
   description = "The BigQuery dataset id to create."
 }
 
+variable "bigquery_project_id" {
+  description = "The project ID where the BigQuery instance exists."
+  type        = string
+}
+
 variable "job_name" {
   type        = string
   description = "The name of the cloud run job"

--- a/terraform/modules/commit_review_status/main.tf
+++ b/terraform/modules/commit_review_status/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "google_bigquery_table" "commit_review_status_table" {
-  project = var.project_id
+  project = var.bigquery_project_id
 
   deletion_protection = false
   table_id            = var.commit_review_status_table_id
@@ -109,7 +109,7 @@ resource "google_bigquery_table" "commit_review_status_table" {
 resource "google_bigquery_table_iam_member" "commit_review_status_owners" {
   for_each = toset(var.commit_review_status_table_iam.owners)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.commit_review_status_table.id
@@ -120,7 +120,7 @@ resource "google_bigquery_table_iam_member" "commit_review_status_owners" {
 resource "google_bigquery_table_iam_member" "commit_review_status_editors" {
   for_each = toset(var.commit_review_status_table_iam.editors)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.commit_review_status_table.id
@@ -131,7 +131,7 @@ resource "google_bigquery_table_iam_member" "commit_review_status_editors" {
 resource "google_bigquery_table_iam_member" "commit_review_status_viewers" {
   for_each = toset(var.commit_review_status_table_iam.viewers)
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = google_bigquery_table.commit_review_status_table.id

--- a/terraform/modules/commit_review_status/variables.tf
+++ b/terraform/modules/commit_review_status/variables.tf
@@ -22,6 +22,11 @@ variable "dataset_id" {
   description = "The BigQuery dataset id to create."
 }
 
+variable "bigquery_project_id" {
+  description = "The project ID where the BigQuery instance exists."
+  type        = string
+}
+
 variable "job_name" {
   type        = string
   description = "The name of the cloud run job"


### PR DESCRIPTION
This PR enhances the Terraform configuration to support deploying the BigQuery resources into a separate Google Cloud project, distinct from the project where the main application services are deployed.