### PR TITLE
retry service should consider the github domain for checkpoints

### DIFF
--- a/pkg/retry/bigquery_mock.go
+++ b/pkg/retry/bigquery_mock.go
@@ -40,14 +40,14 @@ func (f *MockDatastore) WriteFailureEvent(ctx context.Context, failureEventTable
 	return nil
 }
 
-func (f *MockDatastore) RetrieveCheckpointID(ctx context.Context, checkpointTableID string) (string, error) {
+func (f *MockDatastore) RetrieveCheckpointID(ctx context.Context, checkpointTableID, githubDomain string) (string, error) {
 	if f.retrieveCheckpointID != nil {
 		return f.retrieveCheckpointID.res, f.retrieveCheckpointID.err
 	}
 	return "", nil
 }
 
-func (f *MockDatastore) WriteCheckpointID(ctx context.Context, checkpointTableID, deliveryID, createdAt string) error {
+func (f *MockDatastore) WriteCheckpointID(ctx context.Context, checkpointTableID, deliveryID, createdAt, githubDomain string) error {
 	if f.writeCheckpointID != nil {
 		return f.writeCheckpointID.err
 	}

--- a/pkg/retry/config.go
+++ b/pkg/retry/config.go
@@ -24,11 +24,16 @@ import (
 	"github.com/abcxyz/pkg/cli"
 )
 
+const (
+	defaultGitHubDomain = "github.com"
+)
+
 // Config defines the set of environment variables required
 // for running the retry service.
 type Config struct {
 	GitHub githubclient.Config
 
+	GitHubDomain      string
 	BigQueryProjectID string
 	BucketName        string
 	CheckpointTableID string
@@ -72,6 +77,10 @@ func (cfg *Config) Validate(ctx context.Context) error {
 		cfg.BigQueryProjectID = cfg.ProjectID
 	}
 
+	if cfg.GitHubDomain == "" {
+		cfg.GitHubDomain = defaultGitHubDomain
+	}
+
 	return merr
 }
 
@@ -80,6 +89,14 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	cfg.GitHub.ToFlags(set)
 
 	f := set.NewSection("COMMON OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:    "github-domain",
+		Target:  &cfg.GitHubDomain,
+		EnvVar:  "GITHUB_DOMAIN",
+		Default: defaultGitHubDomain,
+		Usage:   `The GitHub domain to run the retry service against.`,
+	})
 
 	// This will default to projectID in the Validate function
 	// and is intentionally not done here.

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -82,7 +82,7 @@ func (s *Server) handleRetry() http.Handler {
 		}
 
 		// read the last checkpoint from checkpoint table
-		prevCheckpoint, err := s.datastore.RetrieveCheckpointID(ctx, s.checkpointTableID)
+		prevCheckpoint, err := s.datastore.RetrieveCheckpointID(ctx, s.checkpointTableID, s.githubDomain)
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to call RetrieveCheckpointID",
 				"code", http.StatusInternalServerError,
@@ -261,7 +261,7 @@ func (s *Server) writeMostRecentCheckpoint(ctx context.Context, w http.ResponseW
 		"prev_checkpoint", prevCheckpoint,
 		"new_checkpoint", newCheckpoint)
 	createdAt := now.Format(time.DateTime)
-	if err := s.datastore.WriteCheckpointID(ctx, s.checkpointTableID, newCheckpoint, createdAt); err != nil {
+	if err := s.datastore.WriteCheckpointID(ctx, s.checkpointTableID, newCheckpoint, createdAt, s.githubDomain); err != nil {
 		logging.FromContext(ctx).ErrorContext(ctx, "failed to call WriteCheckpointID",
 			"code", http.StatusInternalServerError,
 			"body", errWriteCheckpoint,

--- a/pkg/retry/server.go
+++ b/pkg/retry/server.go
@@ -35,8 +35,8 @@ import (
 
 // Datastore adheres to the interaction the retry service has with a datastore.
 type Datastore interface {
-	RetrieveCheckpointID(ctx context.Context, checkpointTableID string) (string, error)
-	WriteCheckpointID(ctx context.Context, checkpointTableID, deliveryID, createdAt string) error
+	RetrieveCheckpointID(ctx context.Context, checkpointTableID, githubDomain string) (string, error)
+	WriteCheckpointID(ctx context.Context, checkpointTableID, deliveryID, createdAt, githubDomain string) error
 	DeliveryEventExists(ctx context.Context, eventsTableID, deliveryID string) (bool, error)
 	Close() error
 }
@@ -52,6 +52,7 @@ type Server struct {
 	datastore         Datastore
 	gcsLock           gcslock.Lockable
 	github            GitHubSource
+	githubDomain      string
 	lockTTL           time.Duration
 	checkpointTableID string
 	eventsTableID     string
@@ -107,6 +108,7 @@ func NewServer(ctx context.Context, h *renderer.Renderer, cfg *Config, rco *Retr
 		lockTTL:           cfg.LockTTL,
 		checkpointTableID: cfg.CheckpointTableID,
 		eventsTableID:     cfg.EventsTableID,
+		githubDomain:      cfg.GitHubDomain,
 	}, nil
 }
 


### PR DESCRIPTION
The default behavior will be to assume github.com with GHES instances given the ability to override.

https://github.com/abcxyz/github-metrics-aggregator/issues/409