### PR TITLE
FIX: Adding github_instance_url to checkpoint table

### DIFF
--- a/terraform/modules/bigquery_infra/main.tf
+++ b/terraform/modules/bigquery_infra/main.tf
@@ -304,7 +304,7 @@ resource "google_bigquery_table" "checkpoint_table" {
       "mode" : "REQUIRED",
       "description" : "Timestamp for when the checkpoint record was created."
     },
-     {
+    {
       "name" : "github_instance_url",
       "type" : "STRING",
       "mode" : "NULLABLE",


### PR DESCRIPTION
This field is used by the retry service and currently exist in the prod table but not in the integration and autopush checkpoint tables.

This is causing this error in the cloud run retry job:

jsonPayload: {
error: "failed to retrieve checkpoint: failed to make read request to BigQuery: googleapi: Error 400: Name github_instance_url not found inside t at [1:99], invalidQuery"