### PR TITLE
Disabling other big query ressource when infra_deploy is false

### DIFF
--- a/terraform/modules/retry/main.tf
+++ b/terraform/modules/retry/main.tf
@@ -154,7 +154,7 @@ resource "google_project_iam_member" "invoker_role" {
 
 // give the service account permission to run bigquery jobs
 resource "google_project_iam_member" "bigquery_job_user_role" {
-  count   = var.bigquery_infra_deploy ? 1 : 0
+  count = var.bigquery_infra_deploy ? 1 : 0
 
   project = var.project_id
 
@@ -164,7 +164,7 @@ resource "google_project_iam_member" "bigquery_job_user_role" {
 
 // give the service account read access to bigquery data set
 resource "google_bigquery_dataset_iam_member" "dataset_viewer_role" {
-  count   = var.bigquery_infra_deploy ? 1 : 0
+  count = var.bigquery_infra_deploy ? 1 : 0
 
   project = var.project_id
 
@@ -175,8 +175,8 @@ resource "google_bigquery_dataset_iam_member" "dataset_viewer_role" {
 
 // give the service account read and write access to the checkpoint table
 resource "google_bigquery_table_iam_member" "checkpoint_table_editor_role" {
-  count   = var.bigquery_infra_deploy ? 1 : 0
-  
+  count = var.bigquery_infra_deploy ? 1 : 0
+
   project = var.project_id
 
   dataset_id = var.dataset_id


### PR DESCRIPTION
disabling other big query resource creation when bigquery_infra_deploy is set to false. This is part of the changes to be able to deploy to Staging.