### PR TITLE
Refactor: Simplify IAM objects and consolidate compute service accounts

### DIFF
--- a/terraform/example_main.tf
+++ b/terraform/example_main.tf
@@ -59,26 +59,22 @@ locals {
 
 
   # IAM Bindings for BigQuery (grouped as objects)
-  dataset_iam = {
-    owners  = []
-    editors = []
-    viewers = []
-  }
+
 
   # IAM for tables, adding service accounts as editors
   events_table_iam = {
-    editors = [local.webhook_run_service_account_member]
+    editors = [local.compute_service_account_member]
   }
   checkpoint_table_iam = {
-    editors = [local.retry_run_service_account_member]
+    editors = [local.compute_service_account_member]
   }
   failure_events_table_iam = {
-    editors = [local.webhook_run_service_account_member]
+    editors = [local.compute_service_account_member]
   }
 
   # Generic IAM lists for BigQuery
-  job_users                = [local.webhook_run_service_account_member, local.retry_run_service_account_member]
-  dataset_metadata_viewers = [local.webhook_run_service_account_member, local.retry_run_service_account_member]
+  job_users                = [local.compute_service_account_member]
+  dataset_metadata_viewers = [local.compute_service_account_member]
 
 
   # --- 3. GMA (Application) Config ---
@@ -93,22 +89,15 @@ locals {
   # Service Account emails/members used by bigquery to grant permissions
   # In a standard chained setup, these would come from module outputs.
   # Static string placeholders used here per strict local requirement.
-  webhook_run_service_account_member = "<WEBHOOK_SA_MEMBER>" # e.g., serviceAccount:webhook-runner@...
-  retry_run_service_account_member   = "<RETRY_SA_MEMBER>"   # e.g., serviceAccount:retry-runner@...
+  compute_service_account_member = "<COMPUTE_SA_MEMBER>" # e.g., serviceAccount:compute-sa@...
 
   # GMA IAM & Feature Toggles
-  webhook_service_iam             = {}
-  retry_service_iam               = {}
-  events_topic_iam                = {}
-  dlq_topic_iam                   = {}
-  dead_letter_sub_iam             = {}
   lock_ttl                        = "5m"
   lock_ttl_clock_skew             = "10s"
   enable_relay_service            = false
   relay_project_id                = ""
   relay_topic_id                  = ""
   relay_sub_service_account_email = ""
-  relay_service_iam               = {}
   dead_letter_topic_id            = ""
 
   # Dashboards and Analytics

--- a/terraform/gma/job_artifacts.tf
+++ b/terraform/gma/job_artifacts.tf
@@ -84,13 +84,12 @@ resource "google_cloud_run_v2_job" "artifacts" {
           }
         }
       }
-      service_account = google_service_account.artifacts_sa[0].email
+      service_account = local.compute_service_account_email
     }
   }
 
   depends_on = [
     google_project_iam_member.artifacts_secret_accessor,
-    google_service_account.artifacts_sa,
   ]
   lifecycle {
     ignore_changes = [
@@ -143,20 +142,12 @@ resource "google_cloud_run_v2_job_iam_binding" "artifacts_job_invokers" {
   members = toset(var.artifacts.job_iam.invokers)
 }
 
-resource "google_service_account" "artifacts_sa" {
-  count = var.artifacts.enabled ? 1 : 0
-
-  project = var.project_id
-
-  account_id = "${var.artifacts.job_name}-sa"
-}
-
 resource "google_project_iam_member" "artifacts_secret_accessor" {
   count = var.artifacts.enabled ? 1 : 0
 
   project = var.project_id
 
-  member = google_service_account.artifacts_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/secretmanager.secretAccessor"
 }
 
@@ -165,7 +156,7 @@ resource "google_project_iam_member" "artifacts_invoker" {
 
   project = var.project_id
 
-  member = google_service_account.artifacts_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/run.invoker"
 }
 
@@ -174,7 +165,7 @@ resource "google_project_iam_member" "artifacts_bigquery_job_user" {
 
   project = var.project_id
 
-  member = google_service_account.artifacts_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/bigquery.jobUser"
 }
 
@@ -185,7 +176,7 @@ resource "google_bigquery_dataset_iam_member" "artifacts_dataset_viewer" {
 
   dataset_id = var.dataset_id
   role       = "roles/bigquery.dataViewer"
-  member     = google_service_account.artifacts_sa[0].member
+  member     = local.compute_service_account_member
 }
 
 resource "google_bigquery_table_iam_member" "artifacts_table_editor" {
@@ -196,7 +187,7 @@ resource "google_bigquery_table_iam_member" "artifacts_table_editor" {
   dataset_id = var.dataset_id
   table_id   = var.artifacts.table_id
   role       = "roles/bigquery.dataEditor"
-  member     = google_service_account.artifacts_sa[0].member
+  member     = local.compute_service_account_member
 }
 
 resource "google_project_iam_member" "artifacts_storage_object_user" {
@@ -204,7 +195,7 @@ resource "google_project_iam_member" "artifacts_storage_object_user" {
 
   project = var.project_id
 
-  member = google_service_account.artifacts_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/storage.objectUser"
 }
 
@@ -227,20 +218,12 @@ resource "google_cloud_scheduler_job" "artifacts_scheduler" {
     http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.artifacts[0].location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.artifacts[0].name}:run"
     oauth_token {
-      service_account_email = google_service_account.artifacts_sa[0].email
+      service_account_email = local.compute_service_account_email
     }
   }
 }
 
-# Allow the ci service account to act as the artifacts job service account.
-# This allows the ci service account to deploy new revisions for the cloud run job.
-resource "google_service_account_iam_member" "artifacts_job_sa_user" {
-  count = var.artifacts.enabled ? 1 : 0
 
-  service_account_id = google_service_account.artifacts_sa[0].name
-  role               = "roles/iam.serviceAccountUser"
-  member             = var.automation_service_account_member
-}
 
 resource "google_storage_bucket" "artifacts_storage_bucket" {
 

--- a/terraform/gma/job_commit_review_status.tf
+++ b/terraform/gma/job_commit_review_status.tf
@@ -77,13 +77,12 @@ resource "google_cloud_run_v2_job" "commit_review_status" {
           }
         }
       }
-      service_account = google_service_account.commit_review_status_sa[0].email
+      service_account = local.compute_service_account_email
     }
   }
 
   depends_on = [
     google_project_iam_member.commit_review_status_secret_accessor,
-    google_service_account.commit_review_status_sa,
   ]
   lifecycle {
     ignore_changes = [
@@ -136,20 +135,12 @@ resource "google_cloud_run_v2_job_iam_binding" "commit_review_status_job_invoker
   members = toset(var.commit_review_status.job_iam.invokers)
 }
 
-resource "google_service_account" "commit_review_status_sa" {
-  count = var.commit_review_status.enabled ? 1 : 0
-
-  project = var.project_id
-
-  account_id = "${var.commit_review_status.job_name}-sa"
-}
-
 resource "google_project_iam_member" "commit_review_status_secret_accessor" {
   count = var.commit_review_status.enabled ? 1 : 0
 
   project = var.project_id
 
-  member = google_service_account.commit_review_status_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/secretmanager.secretAccessor"
 }
 
@@ -158,7 +149,7 @@ resource "google_project_iam_member" "commit_review_status_invoker" {
 
   project = var.project_id
 
-  member = google_service_account.commit_review_status_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/run.invoker"
 }
 
@@ -167,7 +158,7 @@ resource "google_project_iam_member" "commit_review_status_bigquery_job_user" {
 
   project = var.project_id
 
-  member = google_service_account.commit_review_status_sa[0].member
+  member = local.compute_service_account_member
   role   = "roles/bigquery.jobUser"
 }
 
@@ -178,7 +169,7 @@ resource "google_bigquery_dataset_iam_member" "commit_review_status_dataset_view
 
   dataset_id = var.dataset_id
   role       = "roles/bigquery.dataViewer"
-  member     = google_service_account.commit_review_status_sa[0].member
+  member     = local.compute_service_account_member
 }
 
 resource "google_bigquery_table_iam_member" "commit_review_status_table_editor" {
@@ -189,7 +180,7 @@ resource "google_bigquery_table_iam_member" "commit_review_status_table_editor" 
   dataset_id = var.dataset_id
   table_id   = var.commit_review_status.table_id
   role       = "roles/bigquery.dataEditor"
-  member     = google_service_account.commit_review_status_sa[0].member
+  member     = local.compute_service_account_member
 }
 
 resource "google_cloud_scheduler_job" "commit_review_status_scheduler" {
@@ -211,7 +202,7 @@ resource "google_cloud_scheduler_job" "commit_review_status_scheduler" {
     http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.commit_review_status[0].location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.commit_review_status[0].name}:run"
     oauth_token {
-      service_account_email = google_service_account.commit_review_status_sa[0].email
+      service_account_email = local.compute_service_account_email
     }
   }
 }

--- a/terraform/gma/job_retry.tf
+++ b/terraform/gma/job_retry.tf
@@ -103,13 +103,12 @@ resource "google_cloud_run_v2_job" "retry" {
           value = google_storage_bucket.retry_lock.name
         }
       }
-      service_account = google_service_account.retry_sa.email
+      service_account = local.compute_service_account_email
     }
   }
 
   depends_on = [
     google_project_iam_member.retry_secret_accessor,
-    google_service_account.retry_sa,
     google_secret_manager_secret_version.secrets_default_version,
   ]
   lifecycle {
@@ -155,17 +154,10 @@ resource "google_cloud_run_v2_job_iam_binding" "retry_job_invokers" {
   members = toset(var.retry_service_iam.invokers)
 }
 
-resource "google_service_account" "retry_sa" {
-  project = var.project_id
-
-  account_id = "${var.prefix_name}-retry-sa"
-
-}
-
 resource "google_project_iam_member" "retry_secret_accessor" {
   project = var.project_id
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 
   role = "roles/secretmanager.secretAccessor"
 }
@@ -173,7 +165,7 @@ resource "google_project_iam_member" "retry_secret_accessor" {
 resource "google_project_iam_member" "retry_invoker" {
   project = var.project_id
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 
   role = "roles/run.invoker"
 }
@@ -183,7 +175,7 @@ resource "google_project_iam_member" "retry_bigquery_job_user" {
 
   project = var.project_id
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 
   role = "roles/bigquery.jobUser"
 }
@@ -198,7 +190,7 @@ resource "google_bigquery_dataset_iam_member" "retry_dataset_viewer" {
 
   role = "roles/bigquery.dataViewer"
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 }
 
 resource "google_bigquery_table_iam_member" "retry_checkpoint_table_editor" {
@@ -212,13 +204,13 @@ resource "google_bigquery_table_iam_member" "retry_checkpoint_table_editor" {
 
   role = "roles/bigquery.dataEditor"
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 }
 
 resource "google_project_iam_member" "retry_storage_object_user" {
   project = var.project_id
 
-  member = google_service_account.retry_sa.member
+  member = local.compute_service_account_member
 
   role = "roles/storage.objectUser"
 }
@@ -239,7 +231,7 @@ resource "google_cloud_scheduler_job" "retry_scheduler" {
     http_method = "POST"
     uri         = "https://${google_cloud_run_v2_job.retry.location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.retry.name}:run"
     oauth_token {
-      service_account_email = google_service_account.retry_sa.email
+      service_account_email = local.compute_service_account_email
     }
   }
 }

--- a/terraform/gma/outputs.tf
+++ b/terraform/gma/outputs.tf
@@ -28,9 +28,9 @@ output "webhook_run_service" {
     service_id             = module.webhook_cloud_run.service_id
     service_url            = module.webhook_cloud_run.url
     service_name           = module.webhook_cloud_run.service_name
-    service_account_name   = google_service_account.webhook_run_service_account.name
-    service_account_email  = google_service_account.webhook_run_service_account.email
-    service_account_member = google_service_account.webhook_run_service_account.member
+    service_account_name   = local.compute_service_account_name
+    service_account_email  = local.compute_service_account_email
+    service_account_member = local.compute_service_account_member
   }
 }
 
@@ -97,9 +97,9 @@ output "artifacts_job" {
   value = {
     job_id                 = try(google_cloud_run_v2_job.artifacts[0].id, null)
     job_name               = try(google_cloud_run_v2_job.artifacts[0].name, null)
-    service_account_name   = try(google_service_account.artifacts_sa[0].name, null)
-    service_account_email  = try(google_service_account.artifacts_sa[0].email, null)
-    service_account_member = try(google_service_account.artifacts_sa[0].member, null)
+    service_account_name   = var.artifacts.enabled ? local.compute_service_account_name : null
+    service_account_email  = var.artifacts.enabled ? local.compute_service_account_email : null
+    service_account_member = var.artifacts.enabled ? local.compute_service_account_member : null
   }
 }
 
@@ -109,9 +109,9 @@ output "commit_review_status_job" {
   value = {
     job_id                 = try(google_cloud_run_v2_job.commit_review_status[0].id, null)
     job_name               = try(google_cloud_run_v2_job.commit_review_status[0].name, null)
-    service_account_name   = try(google_service_account.commit_review_status_sa[0].name, null)
-    service_account_email  = try(google_service_account.commit_review_status_sa[0].email, null)
-    service_account_member = try(google_service_account.commit_review_status_sa[0].member, null)
+    service_account_name   = var.commit_review_status.enabled ? local.compute_service_account_name : null
+    service_account_email  = var.commit_review_status.enabled ? local.compute_service_account_email : null
+    service_account_member = var.commit_review_status.enabled ? local.compute_service_account_member : null
   }
 }
 
@@ -121,9 +121,9 @@ output "retry_run_job" {
   value = {
     job_id                 = google_cloud_run_v2_job.retry.id
     job_name               = google_cloud_run_v2_job.retry.name
-    service_account_name   = google_service_account.retry_sa.name
-    service_account_email  = google_service_account.retry_sa.email
-    service_account_member = google_service_account.retry_sa.member
+    service_account_name   = local.compute_service_account_name
+    service_account_email  = local.compute_service_account_email
+    service_account_member = local.compute_service_account_member
   }
 }
 
@@ -134,9 +134,9 @@ output "relay_run_service" {
     service_id             = module.relay_cloud_run[0].service_id
     service_url            = module.relay_cloud_run[0].url
     service_name           = module.relay_cloud_run[0].service_name
-    service_account_name   = google_service_account.relay_run_service_account[0].name
-    service_account_email  = google_service_account.relay_run_service_account[0].email
-    service_account_member = google_service_account.relay_run_service_account[0].member
+    service_account_name   = var.enable_relay_service ? local.compute_service_account_name : null
+    service_account_email  = var.enable_relay_service ? local.compute_service_account_email : null
+    service_account_member = var.enable_relay_service ? local.compute_service_account_member : null
   }
 }
 

--- a/terraform/gma/pubsub.tf
+++ b/terraform/gma/pubsub.tf
@@ -77,7 +77,7 @@ resource "google_pubsub_topic_iam_member" "dead_letter_publisher_webhook" {
 
   topic  = google_pubsub_topic.dead_letter.name
   role   = "roles/pubsub.publisher"
-  member = google_service_account.webhook_run_service_account.member
+  member = local.compute_service_account_member
 }
 
 # Allow the PubSub SA to publish the DLQ
@@ -261,7 +261,7 @@ resource "google_pubsub_topic_iam_member" "topic_publisher_webhook" {
 
   topic  = google_pubsub_topic.default.name
   role   = "roles/pubsub.publisher"
-  member = google_service_account.webhook_run_service_account.member
+  member = local.compute_service_account_member
 }
 
 resource "google_pubsub_subscription" "default" {

--- a/terraform/gma/service_account.tf
+++ b/terraform/gma/service_account.tf
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 resource "google_service_account" "compute_sa" {
-  count   = var.compute_service_account_email == "" ? 1 : 0
+  count = var.compute_service_account_email == "" ? 1 : 0
+
   project = data.google_project.default.project_id
 
   account_id   = "${var.prefix_name}-compute"

--- a/terraform/gma/service_account.tf
+++ b/terraform/gma/service_account.tf
@@ -1,0 +1,37 @@
+# Copyright 2026 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "compute_sa" {
+  count   = var.compute_service_account_email == "" ? 1 : 0
+  project = data.google_project.default.project_id
+
+  account_id   = "${var.prefix_name}-compute"
+  display_name = "${var.prefix_name} Compute Service Account"
+}
+
+locals {
+  compute_service_account_email  = var.compute_service_account_email == "" ? google_service_account.compute_sa[0].email : var.compute_service_account_email
+  compute_service_account_name   = var.compute_service_account_email == "" ? google_service_account.compute_sa[0].name : "projects/${data.google_project.default.project_id}/serviceAccounts/${var.compute_service_account_email}"
+  compute_service_account_member = "serviceAccount:${local.compute_service_account_email}"
+}
+
+# Allow the automation service account to act as the compute service account.
+# This enables the automation service account to deploy new revisions for the compute workloads.
+resource "google_service_account_iam_member" "compute_sa_user" {
+  count = var.compute_service_account_email == "" ? 1 : 0
+
+  service_account_id = google_service_account.compute_sa[0].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = var.automation_service_account_member
+}

--- a/terraform/gma/service_relay.tf
+++ b/terraform/gma/service_relay.tf
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_service_account" "relay_run_service_account" {
-  count = var.enable_relay_service ? 1 : 0
-
-  project = data.google_project.default.project_id
-
-  account_id   = "${var.prefix_name}-relay-sa"
-  display_name = "${var.prefix_name}-relay-sa Cloud Run Service Account"
-}
-
 resource "google_pubsub_topic_iam_member" "relay_webhook_topic_subscribers" {
   count = var.enable_relay_service ? 1 : 0
 
@@ -28,7 +19,7 @@ resource "google_pubsub_topic_iam_member" "relay_webhook_topic_subscribers" {
 
   topic  = google_pubsub_topic.default.name
   role   = "roles/pubsub.subscriber"
-  member = google_service_account.relay_run_service_account[0].member
+  member = local.compute_service_account_member
 }
 
 module "relay_cloud_run" {
@@ -43,11 +34,11 @@ module "relay_cloud_run" {
   image                 = var.image
   args                  = ["relay"]
   ingress               = "internal-and-cloud-load-balancing"
-  service_account_email = google_service_account.relay_run_service_account[0].email
+  service_account_email = local.compute_service_account_email
   service_iam = {
     admins     = toset(var.relay_service_iam.admins)
     developers = toset(concat(var.relay_service_iam.developers, [var.automation_service_account_member]))
-    invokers   = toset(concat(var.relay_service_iam.invokers, [google_service_account.relay_sub_service_account[0].member]))
+    invokers   = toset(concat(var.relay_service_iam.invokers, [local.compute_service_account_member]))
   }
   envvars = {
     "PROJECT_ID" : data.google_project.default.project_id,
@@ -58,25 +49,7 @@ module "relay_cloud_run" {
   additional_service_annotations = { "run.googleapis.com/invoker-iam-disabled" : true }
 }
 
-# allow the ci service account to act as the relay cloud run service account
-# this allows the ci service account to deploy new revisions for the cloud run
-# service
-resource "google_service_account_iam_member" "relay_run_sa_user" {
-  count = var.enable_relay_service ? 1 : 0
 
-  service_account_id = google_service_account.relay_run_service_account[0].name
-  role               = "roles/iam.serviceAccountUser"
-  member             = var.automation_service_account_member
-}
-
-resource "google_service_account" "relay_sub_service_account" {
-  count = var.enable_relay_service ? 1 : 0
-
-  project = data.google_project.default.project_id
-
-  account_id   = "${var.prefix_name}-relay-sub-sa"
-  display_name = "${var.prefix_name}-relay-sub-sa PubSub Subscription Identity"
-}
 
 resource "google_pubsub_subscription" "relay" {
   count = var.enable_relay_service ? 1 : 0
@@ -89,7 +62,7 @@ resource "google_pubsub_subscription" "relay" {
   push_config {
     push_endpoint = module.relay_cloud_run[0].url
     oidc_token {
-      service_account_email = google_service_account.relay_sub_service_account[0].email
+      service_account_email = local.compute_service_account_email
     }
   }
 

--- a/terraform/gma/service_webhook.tf
+++ b/terraform/gma/service_webhook.tf
@@ -28,12 +28,7 @@ module "gclb" {
   domains          = var.webhook_domains
 }
 
-resource "google_service_account" "webhook_run_service_account" {
-  project = data.google_project.default.project_id
 
-  account_id   = "${var.prefix_name}-webhook-sa"
-  display_name = "${var.prefix_name}-webhook-sa Cloud Run Service Account"
-}
 
 module "webhook_cloud_run" {
   source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=1467eaf0115f71613727212b0b51b3f99e699842"
@@ -46,7 +41,7 @@ module "webhook_cloud_run" {
   args                  = ["webhook", "server"]
   ingress               = var.enable_webhook_gclb ? "internal-and-cloud-load-balancing" : "all"
   secrets               = ["github-webhook-secret"]
-  service_account_email = google_service_account.webhook_run_service_account.email
+  service_account_email = local.compute_service_account_email
   service_iam = {
     admins     = toset(var.webhook_service_iam.admins)
     developers = toset(concat(var.webhook_service_iam.developers, [var.automation_service_account_member]))
@@ -74,11 +69,3 @@ module "webhook_cloud_run" {
   max_instances = var.webhook_max_instances
 }
 
-# allow the ci service account to act as the webhook cloud run service account
-# this allows the ci service account to deploy new revisions for the cloud run
-# service
-resource "google_service_account_iam_member" "webhook_run_sa_user" {
-  service_account_id = google_service_account.webhook_run_service_account.name
-  role               = "roles/iam.serviceAccountUser"
-  member             = var.automation_service_account_member
-}

--- a/terraform/gma/variables.tf
+++ b/terraform/gma/variables.tf
@@ -59,11 +59,7 @@ variable "webhook_service_iam" {
     developers = optional(list(string), [])
     invokers   = optional(list(string), [])
   })
-  default = {
-    admins     = []
-    developers = []
-    invokers   = []
-  }
+  default = {}
 }
 
 variable "retry_service_iam" {
@@ -73,11 +69,7 @@ variable "retry_service_iam" {
     developers = optional(list(string), [])
     invokers   = optional(list(string), [])
   })
-  default = {
-    admins     = []
-    developers = []
-    invokers   = []
-  }
+  default = {}
 }
 
 variable "events_topic_iam" {
@@ -89,13 +81,7 @@ variable "events_topic_iam" {
     publishers  = optional(list(string), [])
     subscribers = optional(list(string), [])
   })
-  default = {
-    admins      = []
-    editors     = []
-    viewers     = []
-    publishers  = []
-    subscribers = []
-  }
+  default = {}
 }
 
 variable "dlq_topic_iam" {
@@ -107,13 +93,7 @@ variable "dlq_topic_iam" {
     publishers  = optional(list(string), [])
     subscribers = optional(list(string), [])
   })
-  default = {
-    admins      = []
-    editors     = []
-    viewers     = []
-    publishers  = []
-    subscribers = []
-  }
+  default = {}
 }
 
 variable "dead_letter_sub_iam" {
@@ -124,12 +104,13 @@ variable "dead_letter_sub_iam" {
     viewers     = optional(list(string), [])
     subscribers = optional(list(string), [])
   })
-  default = {
-    admins      = []
-    editors     = []
-    viewers     = []
-    subscribers = []
-  }
+  default = {}
+}
+
+variable "compute_service_account_email" {
+  description = "The email of an existing service account to use for the GMA compute services. If left blank, one will be created."
+  type        = string
+  default     = ""
 }
 
 
@@ -202,11 +183,8 @@ variable "artifacts" {
       owners  = optional(list(string), [])
       editors = optional(list(string), [])
       viewers = optional(list(string), [])
-      }), {
-      owners  = []
-      editors = []
-      viewers = []
-    })
+      })
+      default = {}
     bucket_name     = optional(string, null)
     bucket_location = optional(string, null)
     job_name        = optional(string, "artifacts-job")
@@ -214,11 +192,8 @@ variable "artifacts" {
       admins     = optional(list(string), [])
       developers = optional(list(string), [])
       invokers   = optional(list(string), [])
-      }), {
-      admins     = []
-      developers = []
-      invokers   = []
-    })
+      })
+      default = {}
     job_additional_env_vars = optional(map(string), {})
     scheduler_cron          = optional(string, "*/15 * * * *")
     alerts = optional(object({
@@ -249,21 +224,15 @@ variable "commit_review_status" {
       owners  = optional(list(string), [])
       editors = optional(list(string), [])
       viewers = optional(list(string), [])
-      }), {
-      owners  = []
-      editors = []
-      viewers = []
-    })
+      })
+      default = {}
     job_name = optional(string, "commit-review-status-job")
     job_iam = optional(object({
       admins     = optional(list(string), [])
       developers = optional(list(string), [])
       invokers   = optional(list(string), [])
-      }), {
-      admins     = []
-      developers = []
-      invokers   = []
-    })
+      })
+      default = {}
     job_additional_env_vars = optional(map(string), {})
     scheduler_cron          = optional(string, "0 */4 * * *")
     alerts = optional(object({
@@ -377,11 +346,7 @@ variable "relay_service_iam" {
     developers = optional(list(string), [])
     invokers   = optional(list(string), [])
   })
-  default = {
-    admins     = []
-    developers = []
-    invokers   = []
-  }
+  default = {}
 }
 
 variable "relay_topic_id" {


### PR DESCRIPTION
This PR refactors the IAM configuration in the GMA Terraform module to simplify IAM objects and consolidate compute service accounts. It introduces a "Create or Use Existing" pattern for the compute service account, making the module more flexible and the references cleaner.

Changes
Consolidated Compute Service Account: Added logic to either use an existing service account provided via var.compute_service_account_email or create a new one if left blank.
Simplified IAM References: Used locals in service_account.tf to abstract the conditional logic for service account details (email, name, member format). This simplifies how other resources in the module reference the compute service account.