### PR TITLE
Simplify IAM configuration and variables

### DIFF
--- a/terraform/gma/job_retry.tf
+++ b/terraform/gma/job_retry.tf
@@ -118,20 +118,6 @@ resource "google_cloud_run_v2_job" "retry" {
   }
 }
 
-resource "google_cloud_run_v2_job_iam_binding" "retry_job_admins" {
-  count = length(var.retry_service_iam.admins) > 0 ? 1 : 0
-
-  project = google_cloud_run_v2_job.retry.project
-
-  location = google_cloud_run_v2_job.retry.location
-
-
-  name = google_cloud_run_v2_job.retry.name
-
-  role    = "roles/run.admin"
-  members = toset(var.retry_service_iam.admins)
-}
-
 resource "google_cloud_run_v2_job_iam_binding" "retry_job_developers" {
   project = google_cloud_run_v2_job.retry.project
 
@@ -142,20 +128,6 @@ resource "google_cloud_run_v2_job_iam_binding" "retry_job_developers" {
 
   role    = "roles/run.developer"
   members = toset(concat(var.retry_service_iam.developers, [var.automation_service_account_member]))
-}
-
-resource "google_cloud_run_v2_job_iam_binding" "retry_job_invokers" {
-  count = length(var.retry_service_iam.invokers) > 0 ? 1 : 0
-
-  project = google_cloud_run_v2_job.retry.project
-
-  location = google_cloud_run_v2_job.retry.location
-
-
-  name = google_cloud_run_v2_job.retry.name
-
-  role    = "roles/run.invoker"
-  members = toset(var.retry_service_iam.invokers)
 }
 
 resource "google_project_iam_member" "retry_secret_accessor" {

--- a/terraform/gma/job_retry.tf
+++ b/terraform/gma/job_retry.tf
@@ -119,6 +119,8 @@ resource "google_cloud_run_v2_job" "retry" {
 }
 
 resource "google_cloud_run_v2_job_iam_binding" "retry_job_admins" {
+  count = length(var.retry_service_iam.admins) > 0 ? 1 : 0
+
   project = google_cloud_run_v2_job.retry.project
 
   location = google_cloud_run_v2_job.retry.location
@@ -143,6 +145,8 @@ resource "google_cloud_run_v2_job_iam_binding" "retry_job_developers" {
 }
 
 resource "google_cloud_run_v2_job_iam_binding" "retry_job_invokers" {
+  count = length(var.retry_service_iam.invokers) > 0 ? 1 : 0
+
   project = google_cloud_run_v2_job.retry.project
 
   location = google_cloud_run_v2_job.retry.location

--- a/terraform/gma/variables.tf
+++ b/terraform/gma/variables.tf
@@ -65,9 +65,7 @@ variable "webhook_service_iam" {
 variable "retry_service_iam" {
   description = "IAM member bindings for the retry Cloud Run services."
   type = object({
-    admins     = optional(list(string), [])
     developers = optional(list(string), [])
-    invokers   = optional(list(string), [])
   })
   default = {}
 }

--- a/terraform/gma/variables.tf
+++ b/terraform/gma/variables.tf
@@ -346,13 +346,19 @@ variable "relay_service_iam" {
 variable "relay_topic_id" {
   description = "The PubSub topic ID for the relay service to publish to."
   type        = string
-  default     = ""
+  default     = "gma-relay"
 }
 
 variable "relay_project_id" {
   description = "The project ID where the relay PubSub topic exists."
   type        = string
   default     = ""
+}
+
+variable "leech_bucket_name" {
+  description = "The name of the GCS bucket for Dataflow staging/temp."
+  type        = string
+  default     = "gma-df-store"
 }
 
 variable "optimized_events_table_id" {

--- a/terraform/pubsub/main.tf
+++ b/terraform/pubsub/main.tf
@@ -17,7 +17,7 @@ resource "google_pubsub_subscription" "relay_optimized_events" {
   project = var.project_id
 
   name  = "${var.prefix_name}-relay-optimized-events-sub"
-  topic = "projects/${var.relay_project_id}/topics/${var.relay_topic_id}"
+  topic = substr(var.relay_topic_id, 0, 9) == "projects/" ? var.relay_topic_id : "projects/${var.relay_project_id}/topics/${var.relay_topic_id}"
 
   bigquery_config {
     table                 = "${var.project_id}:${var.dataset_id}.${var.optimized_events_table_id}"
@@ -44,7 +44,7 @@ resource "google_pubsub_topic" "relay" {
 
   project = var.relay_project_id
 
-  name = var.relay_topic_id != "" ? var.relay_topic_id : "${var.prefix_name}-relay"
+  name = var.relay_topic_id
 
   schema_settings {
     schema   = var.relay_schema_id

--- a/terraform/pubsub/variables.tf
+++ b/terraform/pubsub/variables.tf
@@ -33,7 +33,7 @@ variable "relay_project_id" {
 variable "relay_topic_id" {
   description = "The topic ID for the relay service."
   type        = string
-  default     = ""
+  default     = "gma-relay"
 }
 
 variable "relay_sub_service_account_email" {


### PR DESCRIPTION
Siimplify GMA variables, handle full topic names, and clean up IAM
This PR simplifies the configuration for the GitHub Metrics Aggregator by pushing defaults for `relay_topic_id` and `leech_bucket_name` directly into the module variables. It also makes the Pub/Sub subscription configuration robust to handle full resource paths.
This change also  simplifies the IAM configuration for the retry Cloud Run job by removing unnecessary bindings.
- Removed `roles/run.admin` and `roles/run.invoker` bindings for the retry job in `job_retry.tf`.
- Removed corresponding `admins` and `invokers` fields from the `retry_service_iam` variable in `variables.tf`.
