### PR TITLE
fix(terraform): Resolve deletion protection, missing variables, and update example

### DIFF
--- a/terraform/bigquery/variables.tf
+++ b/terraform/bigquery/variables.tf
@@ -137,6 +137,16 @@ variable "optimized_events_table_id" {
   default     = "optimized_events"
 }
 
+variable "events_table_iam" {
+  description = "IAM bindings for the optimized events table in {GROUP_TYPE => [MEMBERS]} format."
+  type = object({
+    owners  = optional(list(string), [])
+    editors = optional(list(string), [])
+    viewers = optional(list(string), [])
+  })
+  default = {}
+}
+
 
 
 variable "prstats_pull_requests_table_id" {

--- a/terraform/example_main.tf
+++ b/terraform/example_main.tf
@@ -48,8 +48,6 @@ locals {
 
   # --- 2. BigQuery Dataset & Tables ---
   dataset_id                            = "github_metrics"
-  events_table_id                       = "events"
-  raw_events_table_id                   = "raw_events"
   checkpoint_table_id                   = "checkpoint"
   failure_events_table_id               = "failure_events"
   optimized_events_table_id             = "optimized_events"
@@ -140,8 +138,6 @@ module "bigquery" {
 
   # Dataset & Tables Configuration
   dataset_iam                           = local.dataset_iam
-  events_table_id                       = local.events_table_id
-  raw_events_table_id                   = local.raw_events_table_id
   bigquery_events_partition_granularity = local.bigquery_events_partition_granularity
   events_table_iam                      = local.events_table_iam
   checkpoint_table_id                   = local.checkpoint_table_id
@@ -218,8 +214,6 @@ module "gma" {
 
   # Dataset / Storage references
   dataset_id              = local.dataset_id
-  events_table_id         = local.events_table_id
-  raw_events_table_id     = local.raw_events_table_id
   checkpoint_table_id     = local.checkpoint_table_id
   failure_events_table_id = local.failure_events_table_id
 

--- a/terraform/gma/job_commit_review_status.tf
+++ b/terraform/gma/job_commit_review_status.tf
@@ -165,7 +165,7 @@ resource "google_project_iam_member" "commit_review_status_bigquery_job_user" {
 resource "google_bigquery_dataset_iam_member" "commit_review_status_dataset_viewer" {
   count = var.commit_review_status.enabled ? 1 : 0
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   role       = "roles/bigquery.dataViewer"
@@ -175,7 +175,7 @@ resource "google_bigquery_dataset_iam_member" "commit_review_status_dataset_view
 resource "google_bigquery_table_iam_member" "commit_review_status_table_editor" {
   count = var.commit_review_status.enabled ? 1 : 0
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
   table_id   = var.commit_review_status.table_id

--- a/terraform/gma/job_retry.tf
+++ b/terraform/gma/job_retry.tf
@@ -159,7 +159,7 @@ resource "google_project_iam_member" "retry_bigquery_job_user" {
 resource "google_bigquery_dataset_iam_member" "retry_dataset_viewer" {
   count = var.bigquery_infra_deploy ? 1 : 0
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
 
@@ -172,7 +172,7 @@ resource "google_bigquery_dataset_iam_member" "retry_dataset_viewer" {
 resource "google_bigquery_table_iam_member" "retry_checkpoint_table_editor" {
   count = var.bigquery_infra_deploy ? 1 : 0
 
-  project = var.project_id
+  project = var.bigquery_project_id
 
   dataset_id = var.dataset_id
 

--- a/terraform/gma/job_retry.tf
+++ b/terraform/gma/job_retry.tf
@@ -50,6 +50,8 @@ resource "google_cloud_run_v2_job" "retry" {
   name     = "${var.prefix_name}-retry"
   location = var.region
 
+  deletion_protection = false
+
   template {
     parallelism = 0
     task_count  = 1
@@ -156,6 +158,8 @@ resource "google_project_iam_member" "retry_bigquery_job_user" {
   role = "roles/bigquery.jobUser"
 }
 
+
+
 resource "google_bigquery_dataset_iam_member" "retry_dataset_viewer" {
   count = var.bigquery_infra_deploy ? 1 : 0
 
@@ -167,6 +171,11 @@ resource "google_bigquery_dataset_iam_member" "retry_dataset_viewer" {
   role = "roles/bigquery.dataViewer"
 
   member = local.compute_service_account_member
+
+  depends_on = [
+    google_project_service.bigquery_db,
+    google_project_service.default["bigquery.googleapis.com"],
+  ]
 }
 
 resource "google_bigquery_table_iam_member" "retry_checkpoint_table_editor" {
@@ -181,6 +190,11 @@ resource "google_bigquery_table_iam_member" "retry_checkpoint_table_editor" {
   role = "roles/bigquery.dataEditor"
 
   member = local.compute_service_account_member
+
+  depends_on = [
+    google_project_service.bigquery_db,
+    google_project_service.default["bigquery.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "retry_storage_object_user" {


### PR DESCRIPTION
This PR fixes several issues in the Terraform configuration for the GitHub Metrics Aggregator to ensure successful deployment and resource management.
### Changes
- **Cloud Run Job (`job_retry.tf`):** Disabled deletion protection on the `retry` job to prevent failures during teardown or updates.
- **BigQuery Module (`variables.tf`):** Declared the missing `events_table_iam` variable in the `bigquery` module, resolving validation errors where it was referenced in `table_optimized_events.tf`.
- **Example Configuration (`example_main.tf`):** Removed unsupported `events_table_id` and `raw_events_table_id` arguments from the `gma` and `bigquery` module calls to align with recent refactors that removed these tables.