### PR TITLE
fix(terraform): make bucket IAM conditional

### DIFF
--- a/terraform/gma/job_artifacts.tf
+++ b/terraform/gma/job_artifacts.tf
@@ -199,6 +199,13 @@ resource "google_project_iam_member" "artifacts_storage_object_user" {
   role   = "roles/storage.objectUser"
 }
 
+resource "google_storage_bucket_iam_member" "automation_iam_storage" {
+  count  = var.artifacts.enabled ? 1 : 0
+  bucket = google_storage_bucket.artifacts_storage_bucket[0].name
+  role   = "roles/storage.admin"
+  member = var.automation_service_account_member
+}
+
 resource "google_cloud_scheduler_job" "artifacts_scheduler" {
   count = var.artifacts.enabled ? 1 : 0
 

--- a/terraform/gma/job_artifacts.tf
+++ b/terraform/gma/job_artifacts.tf
@@ -200,7 +200,7 @@ resource "google_project_iam_member" "artifacts_storage_object_user" {
 }
 
 resource "google_storage_bucket_iam_member" "automation_iam_storage" {
-  count  = var.artifacts.enabled ? 1 : 0
+  count = var.artifacts.enabled ? 1 : 0
 
   bucket = google_storage_bucket.artifacts_storage_bucket[0].name
   role   = "roles/storage.admin"

--- a/terraform/gma/job_artifacts.tf
+++ b/terraform/gma/job_artifacts.tf
@@ -201,6 +201,7 @@ resource "google_project_iam_member" "artifacts_storage_object_user" {
 
 resource "google_storage_bucket_iam_member" "automation_iam_storage" {
   count  = var.artifacts.enabled ? 1 : 0
+
   bucket = google_storage_bucket.artifacts_storage_bucket[0].name
   role   = "roles/storage.admin"
   member = var.automation_service_account_member


### PR DESCRIPTION
Move the `google_storage_bucket_iam_member` for the automation bot into the `gma` module and make it conditional on `var.artifacts.enabled`.

Previously, this IAM binding was declared unconditionally in environment configurations (like `autopush` and `integration`), causing errors when the `artifacts` feature was disabled and the bucket was not created.

By moving it into the module and adding the `count` condition, we ensure the IAM binding is only created when the bucket itself is created.

